### PR TITLE
[Heendy 20 store detail] 매장 상세 정보 조회 api 구현

### DIFF
--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -32,7 +32,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final AuthTokenAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/resources/**", "/", "/swagger-ui/**", "/api/v1/auth/**");
+        web.ignoring().antMatchers("/resources/**", "/", "/swagger-ui/**"
+                , "/api/v1/auth/**"
+                , "/api/v1/stores/**");
     }
     @Override
     public void configure(HttpSecurity httpSecurity) throws Exception {
@@ -53,7 +55,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                     .authorizeRequests()
                     .antMatchers("/api/v1/auth/**").permitAll()
-                    .antMatchers("/api/v1/member/**").authenticated()
+                    .antMatchers("/api/v1/stores/**").permitAll()
+                    .antMatchers("/api/v1/members/**").authenticated()
                     .anyRequest().permitAll()
                 .and()
                     .apply(new AuthTokenFilterConfigurer(authTokenGenerator));

--- a/src/main/java/com/hyundai/app/member/controller/AuthController.java
+++ b/src/main/java/com/hyundai/app/member/controller/AuthController.java
@@ -2,10 +2,13 @@ package com.hyundai.app.member.controller;
 
 import com.hyundai.app.member.dto.LoginReqDto;
 import com.hyundai.app.member.dto.LoginResDto;
+import com.hyundai.app.member.service.MemberService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,19 +21,18 @@ import org.springframework.web.bind.annotation.*;
 @Log4j
 @Api("인증/인가용 API")
 @RestController
-@RequiredArgsConstructor
 @RequestMapping("/api/v1/auth")
 public class AuthController {
 
-    // @Qualifier("MemberServiceImpl")
-    private final com.hyundai.app.member.service.MemberServiceImpl memberServiceImpl;
+    @Autowired
+    @Qualifier("memberServiceImpl")
+    private MemberService memberService;
 
     @PostMapping("/login")
     @ApiOperation("회원가입/로그인 API")
     public ResponseEntity<LoginResDto> login(@RequestBody LoginReqDto loginReqDto) {
         log.debug("로그인 시도 => 토큰 : " + loginReqDto.getLoginToken());
-        LoginResDto loginResDto = memberServiceImpl.login(loginReqDto);
+        LoginResDto loginResDto = memberService.login(loginReqDto);
         return new ResponseEntity<>(loginResDto, HttpStatus.ACCEPTED);
-
     }
 }

--- a/src/main/java/com/hyundai/app/store/controller/StoreController.java
+++ b/src/main/java/com/hyundai/app/store/controller/StoreController.java
@@ -1,12 +1,9 @@
 package com.hyundai.app.store.controller;
 
-import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
 import com.hyundai.app.store.service.StoreService;
-import com.hyundai.app.store.service.StoreServiceImpl;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
-import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/hyundai/app/store/controller/StoreController.java
+++ b/src/main/java/com/hyundai/app/store/controller/StoreController.java
@@ -1,0 +1,42 @@
+package com.hyundai.app.store.controller;
+
+import com.hyundai.app.store.dto.ReviewReqDto;
+import com.hyundai.app.store.dto.StoreResDto;
+import com.hyundai.app.store.service.StoreService;
+import com.hyundai.app.store.service.StoreServiceImpl;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 관련 기능 컨트롤러
+ */
+@Api("매장 관련 API")
+@RestController
+@RequestMapping("/api/v1/stores")
+public class StoreController {
+
+    @Autowired
+    @Qualifier("storeServiceImpl")
+    private StoreService storeService;
+
+    /**
+     * @author 황수영
+     * @since 2024/02/13
+     * 매장 상세 조회
+     */
+    @GetMapping("/{storeId}")
+    @ApiOperation("매장 상세 조회 API")
+    public ResponseEntity<StoreResDto> getStoreDetail(
+            @PathVariable int storeId) {
+        StoreResDto storeResDto = storeService.getStoreDetail(storeId);
+        return new ResponseEntity<>(storeResDto, HttpStatus.ACCEPTED);
+    }
+}

--- a/src/main/java/com/hyundai/app/store/domain/Hashtag.java
+++ b/src/main/java/com/hyundai/app/store/domain/Hashtag.java
@@ -1,0 +1,20 @@
+package com.hyundai.app.store.domain;
+
+import lombok.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 해시태그 도메인
+ */
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Hashtag {
+    private int id;
+    private String name;
+    private String category;
+}

--- a/src/main/java/com/hyundai/app/store/domain/Review.java
+++ b/src/main/java/com/hyundai/app/store/domain/Review.java
@@ -1,0 +1,20 @@
+package com.hyundai.app.store.domain;
+
+import com.hyundai.app.common.entity.BaseEntity;
+import lombok.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 리뷰 관련 도메인
+ */
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Review extends BaseEntity {
+
+    private int id;
+    private String content;
+}

--- a/src/main/java/com/hyundai/app/store/domain/Store.java
+++ b/src/main/java/com/hyundai/app/store/domain/Store.java
@@ -1,0 +1,27 @@
+package com.hyundai.app.store.domain;
+
+import lombok.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 도메인
+ */
+
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Store {
+    private int id;
+    private String name;
+    private String contactNumber;
+    private String mainCategory;
+    private String subCategory;
+    private int floor;
+    private String description;
+    private int avgScore;
+
+    // 오픈시간 / 끝나는 시간 일단 제외
+}

--- a/src/main/java/com/hyundai/app/store/domain/StoreHashtag.java
+++ b/src/main/java/com/hyundai/app/store/domain/StoreHashtag.java
@@ -1,0 +1,20 @@
+package com.hyundai.app.store.domain;
+
+import lombok.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 - 해시태그 관계 도메인
+ */
+@Getter
+@Builder
+@ToString
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class StoreHashtag {
+    private int id;
+    private int hashtagId;
+    private int storeId;
+    private int count;
+}

--- a/src/main/java/com/hyundai/app/store/dto/ReviewReqDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/ReviewReqDto.java
@@ -1,0 +1,19 @@
+package com.hyundai.app.store.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 리뷰 관련 요청 DTO
+ */
+@Getter
+public class ReviewReqDto {
+    private int id;
+    private int score;
+    private String content;
+    private List<Integer> hashtagIds;
+    // 이미지 이후에 추가
+}

--- a/src/main/java/com/hyundai/app/store/dto/ReviewResDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/ReviewResDto.java
@@ -1,0 +1,18 @@
+package com.hyundai.app.store.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 리뷰 관련 응답 DTO
+ */
+@Getter
+public class ReviewResDto {
+    private int id;
+    private int score;
+    private String content;
+    private List<String> hashtags;
+}

--- a/src/main/java/com/hyundai/app/store/dto/StoreResDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/StoreResDto.java
@@ -1,0 +1,50 @@
+package com.hyundai.app.store.dto;
+
+import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.Store;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 상세 정보 조회 Res DTO
+ */
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class StoreResDto {
+    private int id;
+    private String name;
+    private String description;
+    private int phone;
+    private int floor;
+    private int avgScore;
+
+    private List<Hashtag> popularHashtags; // 사실 이름만 필요함!
+    private List<ReviewResDto> reviews;
+
+    public static StoreResDto of(Store store) {
+        return StoreResDto.builder()
+                .id(store.getId())
+                .description(store.getDescription())
+                .name(store.getName())
+                .avgScore(store.getAvgScore())
+                .floor(store.getFloor())
+                .build();
+    }
+
+    // TODO: 해당 매장의 리뷰들 조회
+//    public void updateReviews(List<ReviewResDto> reviews) {
+//        this.reviews = reviews;
+//    }
+
+    public void updatePopularHashtags(List<Hashtag> popularHashtags) {
+        this.popularHashtags = popularHashtags;
+    }
+}

--- a/src/main/java/com/hyundai/app/store/enumType/HashTagCategory.java
+++ b/src/main/java/com/hyundai/app/store/enumType/HashTagCategory.java
@@ -1,0 +1,14 @@
+package com.hyundai.app.store.enumType;
+
+import lombok.Getter;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 해시태그 카테고리 목록 enum
+ */
+
+@Getter
+public enum HashTagCategory {
+    FOOD, PRICE, INTERIOR, ELSE;
+}

--- a/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
@@ -1,0 +1,17 @@
+package com.hyundai.app.store.mapper;
+
+import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.Store;
+import org.apache.ibatis.annotations.Param;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 관련 mapper
+ */
+public interface StoreMapper {
+    Store getStoreDetail(@Param("storeId") int storeId);
+    List<Hashtag> getPopularHashtagsOfStore(@Param("storeId") int storeId);
+}

--- a/src/main/java/com/hyundai/app/store/service/StoreService.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreService.java
@@ -1,0 +1,13 @@
+package com.hyundai.app.store.service;
+
+import com.hyundai.app.store.dto.StoreResDto;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 관련 서비스단
+ */
+public interface StoreService {
+
+    StoreResDto getStoreDetail(int storeId);
+}

--- a/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
@@ -1,0 +1,36 @@
+package com.hyundai.app.store.service;
+
+import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.dto.StoreResDto;
+import com.hyundai.app.store.mapper.StoreMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/13
+ * 매장 관련 서비스단 - 구현체
+ */
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class StoreServiceImpl implements StoreService {
+
+    private final StoreMapper storeMapper;
+
+    @Override
+    public StoreResDto getStoreDetail(int storeId) {
+        Store store = storeMapper.getStoreDetail(storeId);
+        log.debug("매장 번호 :" + storeId + " 정보 조회 : " + store.toString());
+        List<Hashtag> popularHashtags = storeMapper.getPopularHashtagsOfStore(storeId);
+        log.debug("가장 많이 선택된 해시태그들 5개 조회 : " + popularHashtags.toString());
+
+        StoreResDto storeResDto = StoreResDto.of(store);
+        storeResDto.updatePopularHashtags(popularHashtags);
+        return storeResDto;
+    }
+}

--- a/src/main/resources/mapper/StoreMapper.xml
+++ b/src/main/resources/mapper/StoreMapper.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hyundai.app.store.mapper.StoreMapper">
+
+    <!--    @author 황수영  -->
+    <!--    @since 2024/02/13  -->
+    <!--    매장 관련 mapper  -->
+
+    <select id="getStoreDetail" resultType="com.hyundai.app.store.domain.Store" >
+        SELECT id AS id
+            , name AS name
+            , contact_number AS contactNumber
+            , main_category AS mainCategory
+            , sub_category AS subCategory
+            , floor AS floor
+            , description AS description
+            , avg_score AS avgScore
+        FROM store
+        WHERE id = #{storeId}
+    </select>
+
+    <select id="getPopularHashtagsOfStore" resultType="com.hyundai.app.store.domain.Hashtag">
+        SELECT hashtag.id AS id
+             , hashtag.name AS name
+             , hashtag.category AS category
+        FROM hashtag
+        INNER JOIN store_hashtag
+        ON hashtag.id = store_hashtag.hashtag_id
+        WHERE store_hashtag.store_id = #{storeId}
+        ORDER BY store_hashtag.count DESC
+        FETCH FIRST 5 ROWS ONLY
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 구현 사항

- 매장 상세 정보 조회
- 최다 빈도 해시태그 5개 함께 조회
  -> 여기서 FETCH 사용했는데, ROWNUM과 성능 차이가 없다고 나오는 긴 하던 데 얘기 해보면 좋을 것 같습니당
```
{
    "id": 12345,
    "name": "SMT 라운지",
    "description": "SM 엔터테인먼트가 운영하는 프라이빗 레스토랑 브랜드 'SMT HOUSE'의 새로운 브랜드입니다. 'Chinatown in Mexico City'라는 컨셉으로 준비한 이국적인 테라스 공간에서 로컬 스파이스와 고수를 공통분모로 한 홍콩식 요리와 멕시칸 요리를 선보입니다.",
    "phone": 0,
    "floor": 6,
    "avgScore": 3,
    "popularHashtags": [
        {
            "id": 100,
            "name": "반찬이 잘나와요",
            "category": "식당"
        },
        // ...
    ],
    "reviews": null
}
```

<img width="713" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/fdbe3a2c-fad3-4064-8b05-0e632e2c0cbf">

![image](https://github.com/hyundai-fruitfruit/backend/assets/77563814/de2eeb2c-c9f7-4a80-ba0e-106563f76d95)



## 참고 사항
- 매장별 리뷰/주요 메뉴는 이후 추가 예정
