### PR TITLE
[Heendy 26 security param] 메소드 파라미터로 JWT 파싱한 멤버아이디 매핑하도록 구현 + 회원 정보 조회 기능

### DIFF
--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.hyundai.app.config;
 
+import com.hyundai.app.security.AuthDetailsService;
 import com.hyundai.app.security.filter.AuthTokenFilterConfigurer;
 import com.hyundai.app.security.handler.AuthTokenAccessDeniedHandler;
 import com.hyundai.app.security.handler.AuthTokenAuthenticationEntryPoint;
@@ -28,6 +29,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
     private final JwtTokenGenerator authTokenGenerator;
+    private final AuthDetailsService authUserDetailsService;
     private final AuthTokenAccessDeniedHandler authTokenAccessDeniedHandler;
     private final AuthTokenAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
@@ -59,7 +61,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .antMatchers("/api/v1/members/**").authenticated()
                     .anyRequest().permitAll()
                 .and()
-                    .apply(new AuthTokenFilterConfigurer(authTokenGenerator));
+                    .apply(new AuthTokenFilterConfigurer(authTokenGenerator, authUserDetailsService));
     }
 
     @Bean

--- a/src/main/java/com/hyundai/app/config/ServletContextConfig.java
+++ b/src/main/java/com/hyundai/app/config/ServletContextConfig.java
@@ -1,12 +1,17 @@
 package com.hyundai.app.config;
 
+import com.hyundai.app.security.methodparam.AuthParameterResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
 
 /**
  * @author 황수영
@@ -15,9 +20,11 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
  */
 @Configuration
 @EnableWebMvc
+@RequiredArgsConstructor
 @ComponentScan("com.hyundai.app")
 public class ServletContextConfig implements WebMvcConfigurer {
 
+    private final AuthParameterResolver authParameterResolver;
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
         configurer
@@ -29,5 +36,10 @@ public class ServletContextConfig implements WebMvcConfigurer {
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
         registry.addResourceHandler("/resources/**").addResourceLocations("/resources/");
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(authParameterResolver);
     }
 }

--- a/src/main/java/com/hyundai/app/member/controller/MemberController.java
+++ b/src/main/java/com/hyundai/app/member/controller/MemberController.java
@@ -1,0 +1,37 @@
+package com.hyundai.app.member.controller;
+
+import com.hyundai.app.member.dto.MemberResDto;
+import com.hyundai.app.member.service.MemberService;
+import com.hyundai.app.security.methodparam.MemberId;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/14
+ * 회원 관련 기능 컨트롤러
+ */
+@Log4j
+@Api("회원 관련 API")
+@RestController
+@RequestMapping("/api/v1/members")
+public class MemberController {
+
+    @Autowired
+    @Qualifier("memberServiceImpl")
+    private MemberService memberService;
+
+    @GetMapping
+    @ApiOperation("회원 정보 조회 API")
+    public ResponseEntity<MemberResDto> login(@MemberId Integer memberId) {
+        log.debug("회원 정보 조회 : " + memberId);
+        MemberResDto memberResDto = memberService.getMemberInfo(memberId);
+        return new ResponseEntity<>(memberResDto, HttpStatus.ACCEPTED);
+    }
+}

--- a/src/main/java/com/hyundai/app/member/service/MemberService.java
+++ b/src/main/java/com/hyundai/app/member/service/MemberService.java
@@ -12,7 +12,7 @@ import com.hyundai.app.member.enumType.OauthType;
  */
 public interface MemberService {
 
-    MemberResDto getMember(String id);
+    MemberResDto getMemberInfo(int id);
 
     LoginResDto login(LoginReqDto loginReqDto);
 

--- a/src/main/java/com/hyundai/app/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/hyundai/app/member/service/MemberServiceImpl.java
@@ -33,8 +33,8 @@ public class MemberServiceImpl implements MemberService {
     private final KakaoOauthClient oAuthClient;
     private final JwtTokenGenerator authTokenGenerator;
 
-    public MemberResDto getMember(String id) {
-        Member member = memberMapper.findById(Integer.parseInt(id));
+    public MemberResDto getMemberInfo(int id) {
+        Member member = memberMapper.findById(id);
         return MemberResDto.of(member);
     }
 

--- a/src/main/java/com/hyundai/app/security/AuthDetailsService.java
+++ b/src/main/java/com/hyundai/app/security/AuthDetailsService.java
@@ -4,16 +4,9 @@ import com.hyundai.app.member.mapper.MemberMapper;
 import com.hyundai.app.member.domain.Member;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
-import org.springframework.security.core.GrantedAuthority;
-import org.springframework.security.core.authority.SimpleGrantedAuthority;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
-
-import java.util.ArrayList;
-import java.util.Collection;
 
 /**
  * @author 황수영
@@ -28,19 +21,9 @@ public class AuthDetailsService implements UserDetailsService {
     private final MemberMapper memberMapper;
 
     @Override
-    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+    public AuthUserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
         Member member = memberMapper.findById(Integer.parseInt(id));
         log.debug("loadUserByUsername() => member : " + member);
-        return createUserDetails(member);
-    }
-
-    private UserDetails createUserDetails(Member member) {
-        Collection<GrantedAuthority> grantedAuthorities = new ArrayList<>();
-        grantedAuthorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
-
-        return new User(
-                String.valueOf(member.getId()),
-                String.valueOf(member.getId()),
-                grantedAuthorities);
+        return new AuthUserDetails(member);
     }
 }

--- a/src/main/java/com/hyundai/app/security/AuthUserDetails.java
+++ b/src/main/java/com/hyundai/app/security/AuthUserDetails.java
@@ -1,0 +1,61 @@
+package com.hyundai.app.security;
+
+import com.hyundai.app.member.domain.Member;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+/**
+ * @author 황수영
+ * @since 2024/02/14
+ * (설명)
+ */
+
+@Getter
+@RequiredArgsConstructor
+public class AuthUserDetails implements UserDetails {
+
+    private final Member member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        Collection<GrantedAuthority> authorities = new ArrayList<>();
+        authorities.add(new SimpleGrantedAuthority(member.getRole().toString()));
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return false;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return false;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return false;
+    }
+}

--- a/src/main/java/com/hyundai/app/security/filter/AuthTokenFilterConfigurer.java
+++ b/src/main/java/com/hyundai/app/security/filter/AuthTokenFilterConfigurer.java
@@ -1,5 +1,6 @@
 package com.hyundai.app.security.filter;
 
+import com.hyundai.app.security.AuthDetailsService;
 import com.hyundai.app.security.jwt.JwtTokenGenerator;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
@@ -20,10 +21,11 @@ import org.springframework.stereotype.Component;
 public class AuthTokenFilterConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     private final JwtTokenGenerator jwtTokenGenerator;
+    private final AuthDetailsService authUserDetailsService;
 
     @Override
     public void configure(HttpSecurity httpSecurity) {
-        AuthTokenFilter customFilter = new AuthTokenFilter(jwtTokenGenerator);
+        AuthTokenFilter customFilter = new AuthTokenFilter(jwtTokenGenerator, authUserDetailsService);
         httpSecurity.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
     }
 }

--- a/src/main/java/com/hyundai/app/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/hyundai/app/security/jwt/JwtTokenGenerator.java
@@ -4,6 +4,7 @@ import com.hyundai.app.exception.AdventureOfHeendyException;
 import com.hyundai.app.exception.ErrorCode;
 import com.hyundai.app.member.dto.LoginResDto;
 import com.hyundai.app.security.AuthDetailsService;
+import com.hyundai.app.security.AuthUserDetails;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
@@ -16,6 +17,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.Base64;
 import java.util.Date;
+
+import static com.hyundai.app.member.enumType.Header.BEARER;
 
 /**
  * @author 황수영
@@ -42,7 +45,7 @@ public class JwtTokenGenerator implements InitializingBean {
 
     public Authentication getAuthentication(String accessToken) {
         Claims claims = getClaims(accessToken);
-        UserDetails userDetails = authDetailsService.loadUserByUsername(claims.getSubject());
+        AuthUserDetails userDetails = authDetailsService.loadUserByUsername(claims.getSubject());
         log.debug("AuthTokenGenerator getAuthentication() userDetails : " + userDetails);
 
         return new UsernamePasswordAuthenticationToken(
@@ -54,8 +57,8 @@ public class JwtTokenGenerator implements InitializingBean {
         String refreshToken = createJwtToken(id, refreshValidity);
 
         return LoginResDto.builder()
-                .accessToken(com.hyundai.app.member.enumType.Header.BEARER.getValue() + accessToken)
-                .refreshToken(com.hyundai.app.member.enumType.Header.BEARER.getValue() + refreshToken)
+                .accessToken(BEARER.getValue() + accessToken)
+                .refreshToken(BEARER.getValue() + refreshToken)
                 .build();
     }
 
@@ -83,7 +86,7 @@ public class JwtTokenGenerator implements InitializingBean {
         }
     }
 
-    public void isTokenValidate(String token) throws Exception {
+    public void isTokenValidate(String token) {
         try {
             Jwts.parser()
                 .setSigningKey(jwtSecret)

--- a/src/main/java/com/hyundai/app/security/methodparam/AuthParameterResolver.java
+++ b/src/main/java/com/hyundai/app/security/methodparam/AuthParameterResolver.java
@@ -1,0 +1,40 @@
+package com.hyundai.app.security.methodparam;
+
+import com.hyundai.app.security.AuthUserDetails;
+import lombok.extern.log4j.Log4j;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+/**
+ * @author 황수영
+ * @since 2024/02/14
+ * 메소드 파라미터 설정 클래스
+ */
+@Log4j
+@Component
+public class AuthParameterResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(MemberId.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        AuthUserDetails principal = (AuthUserDetails) authentication.getPrincipal();
+        log.debug("AuthParameterResolver : member " + principal.getMember());
+        return principal.getMember().getId();
+    }
+}

--- a/src/main/java/com/hyundai/app/security/methodparam/MemberId.java
+++ b/src/main/java/com/hyundai/app/security/methodparam/MemberId.java
@@ -1,0 +1,16 @@
+package com.hyundai.app.security.methodparam;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * @author 황수영
+ * @since 2024/02/14
+ * JWT에서 파싱된 멤버 id용 어노테이션
+ */
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface MemberId {
+}


### PR DESCRIPTION
## 구현 사항
- **메소드 파라미터로 JWT 파싱한 멤버아이디 매핑하도록 구현**
  - @ MemberId 로 멤버 아이디 받아서 사용하면 됩니당
  - (/auth/** 같은 JWT 토큰 헤더에 안 받아오는 path 제외)
- **회원 정보 조회 기능 구현**
  - 위 기능 테스트 

<img width="707" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/8f0e305b-764d-46d4-9199-2b8025e803d7">


## 참고 사항

