### PR TITLE
Heendy 25 review create 리뷰(별점/해시태그) 작성 기능 구현

### DIFF
--- a/src/main/java/com/hyundai/app/common/admin/AdminController.java
+++ b/src/main/java/com/hyundai/app/common/admin/AdminController.java
@@ -5,7 +5,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-
 @RequestMapping("/")
 @RestController
 public class AdminController {

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -34,10 +34,12 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     private final AuthTokenAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     public void configure(WebSecurity web) {
-        web.ignoring().antMatchers("/resources/**", "/", "/swagger-ui/**"
-                , "/api/v1/auth/**"
-                , "/api/v1/stores/**");
+        web.ignoring().antMatchers(
+                "/resources/**", "/",
+                "/swagger-ui/**"
+                , "/api/v1/auth/**");
     }
+
     @Override
     public void configure(HttpSecurity httpSecurity) throws Exception {
 
@@ -57,7 +59,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                     .authorizeRequests()
                     .antMatchers("/api/v1/auth/**").permitAll()
-                    .antMatchers("/api/v1/stores/**").permitAll()
+                    .antMatchers("/api/v1/stores/**").authenticated()
                     .antMatchers("/api/v1/members/**").authenticated()
                     .anyRequest().permitAll()
                 .and()

--- a/src/main/java/com/hyundai/app/exception/ErrorCode.java
+++ b/src/main/java/com/hyundai/app/exception/ErrorCode.java
@@ -23,9 +23,18 @@ public enum ErrorCode {
     REFRESH_TOKEN_INVALID(UNAUTHORIZED,  "Refresh Token이 유효하지 않습니다."),
     // OAuth
     OAUTH_UNAUTHORIZED(UNAUTHORIZED, "OAuth 인증에 실패했습니다."),
-
+    // 인증 및 인가
     UNAUTHORIZED_ACCESS(UNAUTHORIZED, "인증되지 않은 사용자입니다."),
     FORBIDDEN_ACCESS(FORBIDDEN, "인가되지 않은 접근입니다."),
+
+    // 리뷰
+    REVIEW_SCORE_INVALID(BAD_REQUEST, "별점은 1~5점까지의 정수이어야 합니다."),
+    REVIEW_CONTENT_INVALID(BAD_REQUEST, "리뷰 내용은 최소 5자 이상이어야합니다."),
+
+    // 아이디값
+    STORE_ID_INVALID(BAD_REQUEST, "해당하는 매장 id가 없습니다."),
+    HASHTAG_ID_INVALID(BAD_REQUEST, "해당하는 해시태그 id가 없습니다."),
+    MEMBER_ID_INVALID(BAD_REQUEST, "해당하는 회원 id가 없습니다."),
 
     // 500 에러
     SERVER_UNAVAILABLE(SERVICE_UNAVAILABLE, "서버에 오류가 발생하였습니다."),

--- a/src/main/java/com/hyundai/app/security/AuthUserDetails.java
+++ b/src/main/java/com/hyundai/app/security/AuthUserDetails.java
@@ -13,7 +13,7 @@ import java.util.Collection;
 /**
  * @author 황수영
  * @since 2024/02/14
- * (설명)
+ * 시큐리티의 UserDetails 자체 구현, Authentication에 Member저장
  */
 
 @Getter

--- a/src/main/java/com/hyundai/app/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/hyundai/app/security/jwt/JwtTokenGenerator.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;

--- a/src/main/java/com/hyundai/app/store/controller/StoreController.java
+++ b/src/main/java/com/hyundai/app/store/controller/StoreController.java
@@ -1,5 +1,7 @@
 package com.hyundai.app.store.controller;
 
+import com.hyundai.app.security.methodparam.MemberId;
+import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
 import com.hyundai.app.store.service.StoreService;
 import io.swagger.annotations.Api;
@@ -35,5 +37,21 @@ public class StoreController {
             @PathVariable int storeId) {
         StoreResDto storeResDto = storeService.getStoreDetail(storeId);
         return new ResponseEntity<>(storeResDto, HttpStatus.ACCEPTED);
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/14
+     * 매장 리뷰 작성
+     */
+    @PostMapping("/{storeId}/reviews")
+    @ApiOperation("매장 리뷰 작성 API")
+    public ResponseEntity<Void> createReview(
+            @PathVariable int storeId,
+            @RequestBody ReviewReqDto reviewReqDto,
+            @MemberId int memberId
+    ) {
+        storeService.createReview(storeId, memberId, reviewReqDto);
+        return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
 }

--- a/src/main/java/com/hyundai/app/store/domain/Review.java
+++ b/src/main/java/com/hyundai/app/store/domain/Review.java
@@ -1,6 +1,7 @@
 package com.hyundai.app.store.domain;
 
 import com.hyundai.app.common.entity.BaseEntity;
+import com.hyundai.app.store.dto.ReviewReqDto;
 import lombok.*;
 
 /**
@@ -15,6 +16,19 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {
 
-    private int id;
+    private String id;
+    private int memberId;
+    private int storeId;
+    private int isDeleted;
+    private int score;
     private String content;
+
+    public static Review from(ReviewReqDto reviewReqDto, int storeId, int memberId) {
+        return Review.builder()
+                .score(reviewReqDto.getScore())
+                .content(reviewReqDto.getContent())
+                .memberId(memberId)
+                .storeId(storeId)
+                .build();
+    }
 }

--- a/src/main/java/com/hyundai/app/store/domain/Review.java
+++ b/src/main/java/com/hyundai/app/store/domain/Review.java
@@ -23,7 +23,7 @@ public class Review extends BaseEntity {
     private int score;
     private String content;
 
-    public static Review from(ReviewReqDto reviewReqDto, int storeId, int memberId) {
+    public static Review create(ReviewReqDto reviewReqDto, int storeId, int memberId) {
         return Review.builder()
                 .score(reviewReqDto.getScore())
                 .content(reviewReqDto.getContent())

--- a/src/main/java/com/hyundai/app/store/domain/Store.java
+++ b/src/main/java/com/hyundai/app/store/domain/Store.java
@@ -7,7 +7,6 @@ import lombok.*;
  * @since 2024/02/13
  * 매장 도메인
  */
-
 @Getter
 @Builder
 @ToString
@@ -21,7 +20,7 @@ public class Store {
     private String subCategory;
     private int floor;
     private String description;
-    private int avgScore;
-
+    private float avgScore;
+    private int reviewCount;
     // 오픈시간 / 끝나는 시간 일단 제외
 }

--- a/src/main/java/com/hyundai/app/store/dto/ReviewReqDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/ReviewReqDto.java
@@ -11,7 +11,6 @@ import java.util.List;
  */
 @Getter
 public class ReviewReqDto {
-    private int id;
     private int score;
     private String content;
     private List<Integer> hashtagIds;

--- a/src/main/java/com/hyundai/app/store/dto/StoreResDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/StoreResDto.java
@@ -24,9 +24,9 @@ public class StoreResDto {
     private String description;
     private int phone;
     private int floor;
-    private int avgScore;
+    private float avgScore;
 
-    private List<Hashtag> popularHashtags; // 사실 이름만 필요함!
+    private List<Hashtag> popularHashtags;
     private List<ReviewResDto> reviews;
 
     public static StoreResDto of(Store store) {

--- a/src/main/java/com/hyundai/app/store/mapper/HashtagMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/HashtagMapper.java
@@ -1,0 +1,18 @@
+package com.hyundai.app.store.mapper;
+
+import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.StoreHashtag;
+import org.apache.ibatis.annotations.Param;
+
+/**
+ * @author 황수영
+ * @since 2024/02/17
+ * 해시태그 관련 매퍼
+ */
+public interface HashtagMapper {
+
+    Hashtag getHashtag(@Param("hashtagId") int hashtagId);
+    void createStoreHashtag(@Param("storeId") int storeId, @Param("hashtagId") int hashtagId);
+    StoreHashtag getStoreHashtag(@Param("storeId") int storeId, @Param("hashtagId") int hashtagId);
+    void updateStoreHashtag(@Param("storeId") int storeId, @Param("hashtagId") int hashtagId);
+}

--- a/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
@@ -1,6 +1,7 @@
 package com.hyundai.app.store.mapper;
 
 import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.Review;
 import com.hyundai.app.store.domain.Store;
 import org.apache.ibatis.annotations.Param;
 
@@ -14,4 +15,7 @@ import java.util.List;
 public interface StoreMapper {
     Store getStoreDetail(@Param("storeId") int storeId);
     List<Hashtag> getPopularHashtagsOfStore(@Param("storeId") int storeId);
+    void saveReview(@Param("review") Review review);
+    void updateAvgScore(@Param("storeId") int storeId, @Param("avgScore") float avgScore);
+    void updateReviewCount(@Param("storeId") int storeId);
 }

--- a/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
@@ -16,6 +16,6 @@ public interface StoreMapper {
     Store getStoreDetail(@Param("storeId") int storeId);
     List<Hashtag> getPopularHashtagsOfStore(@Param("storeId") int storeId);
     void saveReview(@Param("review") Review review);
-    void updateAvgScore(@Param("storeId") int storeId, @Param("avgScore") float avgScore);
+    void updateAvgScore(@Param("storeId") int storeId, @Param("avgScore") double avgScore);
     void updateReviewCount(@Param("storeId") int storeId);
 }

--- a/src/main/java/com/hyundai/app/store/service/StoreService.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreService.java
@@ -1,5 +1,6 @@
 package com.hyundai.app.store.service;
 
+import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
 
 /**
@@ -10,4 +11,5 @@ import com.hyundai.app.store.dto.StoreResDto;
 public interface StoreService {
 
     StoreResDto getStoreDetail(int storeId);
+    void createReview(int storeId, int memberId, ReviewReqDto reviewReqDto);
 }

--- a/src/main/java/com/hyundai/app/store/service/StoreService.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreService.java
@@ -3,6 +3,8 @@ package com.hyundai.app.store.service;
 import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
 
+import java.util.List;
+
 /**
  * @author 황수영
  * @since 2024/02/13
@@ -12,4 +14,5 @@ public interface StoreService {
 
     StoreResDto getStoreDetail(int storeId);
     void createReview(int storeId, int memberId, ReviewReqDto reviewReqDto);
+    void createStoreHashtag(int storeId, List<Integer> hashtagIds);
 }

--- a/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
@@ -59,7 +59,7 @@ public class StoreServiceImpl implements StoreService {
     @Transactional(rollbackFor = Exception.class)
     public void createReview(int storeId, int memberId, ReviewReqDto reviewReqDto) {
         validateReviewRequest(reviewReqDto);
-        Review review = Review.from(reviewReqDto, storeId, memberId);
+        Review review = Review.create(reviewReqDto, storeId, memberId);
         storeMapper.saveReview(review);
         createStoreHashtag(storeId, reviewReqDto.getHashtagIds());
         log.debug("리뷰 작성" + review);

--- a/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
@@ -13,6 +13,7 @@ import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.text.DecimalFormat;
 import java.util.List;
 
 import static com.hyundai.app.exception.ErrorCode.*;
@@ -64,7 +65,7 @@ public class StoreServiceImpl implements StoreService {
         createStoreHashtag(storeId, reviewReqDto.getHashtagIds());
         log.debug("리뷰 작성" + review);
 
-        float newAvgScore = calcAvgScore(storeId, reviewReqDto.getScore());
+        double newAvgScore = calcAvgScore(storeId, reviewReqDto.getScore());
         storeMapper.updateAvgScore(storeId, newAvgScore);
         storeMapper.updateReviewCount(storeId);
     }
@@ -74,15 +75,16 @@ public class StoreServiceImpl implements StoreService {
      * @since 2024/02/14
      * 평점 업데이트 계산
      */
-    private float calcAvgScore(int storeId, int newScore) {
+    private double calcAvgScore(int storeId, int newScore) {
         Store store = storeMapper.getStoreDetail(storeId);
         int reviewCount = store.getReviewCount();
         float avgScore = store.getAvgScore();
         log.debug("별점 업데이트 => reviewCount : " + reviewCount + ", avgScore : " + avgScore);
 
-        float resultScore = ((avgScore * reviewCount) + newScore) / (reviewCount + 1);
-        log.debug("별점 결과" + resultScore);
-        return resultScore;
+        double resultScore = ((avgScore * reviewCount) + newScore) / (reviewCount + 1);
+        double formattedScore = Math.round(resultScore * 10.0) / 10.0;
+        log.debug("별점 결과 : " + formattedScore);
+        return formattedScore;
     }
 
     /**

--- a/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
@@ -1,18 +1,25 @@
 package com.hyundai.app.store.service;
 
+import com.hyundai.app.exception.AdventureOfHeendyException;
 import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.Review;
 import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
 import com.hyundai.app.store.mapper.StoreMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
+import static com.hyundai.app.exception.ErrorCode.*;
+
 /**
+ *
  * @author 황수영
- * @since 2024/02/13
+ * @since 2024 /02/13
  * 매장 관련 서비스단 - 구현체
  */
 @Log4j
@@ -20,8 +27,15 @@ import java.util.List;
 @RequiredArgsConstructor
 public class StoreServiceImpl implements StoreService {
 
+    private static final int REVIEW_MIN_LENGTH = 5;
+    private static final int SCORE_MAX_LENGTH = 5;
     private final StoreMapper storeMapper;
 
+    /**
+     * @author 황수영
+     * @since 2024/02/14
+     * 매장 상세 정보/해시태그/이미지 조회
+     */
     @Override
     public StoreResDto getStoreDetail(int storeId) {
         Store store = storeMapper.getStoreDetail(storeId);
@@ -32,5 +46,55 @@ public class StoreServiceImpl implements StoreService {
         StoreResDto storeResDto = StoreResDto.of(store);
         storeResDto.updatePopularHashtags(popularHashtags);
         return storeResDto;
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/14
+     * 리뷰 작성
+     */
+    @Override
+    @Transactional(rollbackFor = Exception.class)
+    public void createReview(int storeId, int memberId, ReviewReqDto reviewReqDto) {
+        validateReviewRequest(reviewReqDto);
+        Review review = Review.from(reviewReqDto, storeId, memberId);
+        storeMapper.saveReview(review);
+        log.debug("리뷰 작성" + review);
+
+        float newAvgScore = calcAvgScore(storeId, reviewReqDto.getScore());
+        storeMapper.updateAvgScore(storeId, newAvgScore);
+        storeMapper.updateReviewCount(storeId);
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/14
+     * 평점 업데이트 계산
+     */
+    public float calcAvgScore(int storeId, int newScore) {
+        Store store = storeMapper.getStoreDetail(storeId);
+        int reviewCount = store.getReviewCount();
+        float avgScore = store.getAvgScore();
+        log.debug("별점 업데이트 => reviewCount : " + reviewCount + ", avgScore : " + avgScore);
+
+        float resultScore = ((avgScore * reviewCount) + newScore) / (reviewCount + 1);
+        log.debug("별점 결과" + resultScore);
+        return resultScore;
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/14
+     * 리뷰 유효성 검증 로직
+     */
+    public void validateReviewRequest(ReviewReqDto reviewReqDto) {
+        if (reviewReqDto.getContent().length() < REVIEW_MIN_LENGTH) {
+            log.error("리뷰 길이가 5자 이상이어야 합니다.");
+            throw new AdventureOfHeendyException(REVIEW_CONTENT_INVALID);
+        }
+        if (reviewReqDto.getScore() > SCORE_MAX_LENGTH) {
+            log.error("평점은 5점 이내이어야 합니다.");
+            throw new AdventureOfHeendyException(REVIEW_SCORE_INVALID);
+        }
     }
 }

--- a/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
@@ -6,6 +6,7 @@ import com.hyundai.app.store.domain.Review;
 import com.hyundai.app.store.domain.Store;
 import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
+import com.hyundai.app.store.mapper.HashtagMapper;
 import com.hyundai.app.store.mapper.StoreMapper;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
@@ -17,7 +18,6 @@ import java.util.List;
 import static com.hyundai.app.exception.ErrorCode.*;
 
 /**
- *
  * @author 황수영
  * @since 2024 /02/13
  * 매장 관련 서비스단 - 구현체
@@ -29,7 +29,9 @@ public class StoreServiceImpl implements StoreService {
 
     private static final int REVIEW_MIN_LENGTH = 5;
     private static final int SCORE_MAX_LENGTH = 5;
+
     private final StoreMapper storeMapper;
+    private final HashtagMapper hashtagMapper;
 
     /**
      * @author 황수영
@@ -59,6 +61,7 @@ public class StoreServiceImpl implements StoreService {
         validateReviewRequest(reviewReqDto);
         Review review = Review.from(reviewReqDto, storeId, memberId);
         storeMapper.saveReview(review);
+        createStoreHashtag(storeId, reviewReqDto.getHashtagIds());
         log.debug("리뷰 작성" + review);
 
         float newAvgScore = calcAvgScore(storeId, reviewReqDto.getScore());
@@ -71,7 +74,7 @@ public class StoreServiceImpl implements StoreService {
      * @since 2024/02/14
      * 평점 업데이트 계산
      */
-    public float calcAvgScore(int storeId, int newScore) {
+    private float calcAvgScore(int storeId, int newScore) {
         Store store = storeMapper.getStoreDetail(storeId);
         int reviewCount = store.getReviewCount();
         float avgScore = store.getAvgScore();
@@ -95,6 +98,49 @@ public class StoreServiceImpl implements StoreService {
         if (reviewReqDto.getScore() > SCORE_MAX_LENGTH) {
             log.error("평점은 5점 이내이어야 합니다.");
             throw new AdventureOfHeendyException(REVIEW_SCORE_INVALID);
+        }
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/17
+     * 리뷰 작성 시, 매장별 해시태그 리스트 추가
+     */
+    @Transactional
+    @Override
+    public void createStoreHashtag(int storeId, List<Integer> hashtagIds) {
+        log.error("매장 id : " + storeId + " 해시태그 id들 : " + hashtagIds + " 추가");
+
+        for (int hashtagId : hashtagIds) {
+            validateIfHashtagIdExist(hashtagId);
+            handleStoreHashtag(storeId, hashtagId);
+        }
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/17
+     * 리뷰 작성 시, 매장별 해시태그 개별 추가 (긴 메소드 분리 용도)
+     */
+    private void handleStoreHashtag(int storeId, int hashtagId) {
+        if (hashtagMapper.getStoreHashtag(storeId, hashtagId) != null) {
+            log.debug("해시태그 id: " + hashtagId + " 이미 있을 경우 count만 증가");
+            hashtagMapper.updateStoreHashtag(storeId, hashtagId);
+        } else {
+            log.debug("해시태그 id: " + hashtagId + " 없을 경우 새로 생성");
+            hashtagMapper.createStoreHashtag(storeId, hashtagId);
+        }
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/17
+     * 해시 태그 아이디가 없을 경우 에러 반환
+     */
+    private void validateIfHashtagIdExist(int hashtagId) {
+        if (hashtagMapper.getHashtag(hashtagId) == null) {
+            log.error("해시태그 id: " + hashtagId + "가 존재하지 않습니다.");
+            throw new AdventureOfHeendyException(HASHTAG_ID_INVALID);
         }
     }
 }

--- a/src/main/resources/mapper/HashtagMapper.xml
+++ b/src/main/resources/mapper/HashtagMapper.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hyundai.app.store.mapper.HashtagMapper">
+
+    <!--    @author 황수영  -->
+    <!--    @since 2024/02/17  -->
+    <!--    해시 태그 관련 mapper  -->
+
+    <select id="getHashtag" resultType="com.hyundai.app.store.domain.Hashtag" >
+        SELECT
+            id AS id
+            , name AS name
+            , category AS category
+        FROM hashtag
+        WHERE id = #{hashtagId}
+    </select>
+
+    <insert id="createStoreHashtag">
+        INSERT INTO store_hashtag (
+            id
+            , hashtag_id
+            , store_id
+            , count
+        )
+        VALUES (
+            store_hashtag_id_seq.nextval
+            , #{hashtagId}
+            , #{storeId}
+            , 1
+        )
+    </insert>
+
+    <select id="getStoreHashtag" resultType="com.hyundai.app.store.domain.StoreHashtag" >
+        SELECT
+            id AS id
+            , hashtag_id AS hashtagId
+            , store_id AS storeId
+            , count AS count
+        FROM store_hashtag
+        WHERE hashtag_id = #{hashtagId}
+        AND store_id = #{storeId}
+    </select>
+
+    <update id="updateStoreHashtag">
+        UPDATE store_hashtag
+        SET count = count + 1
+        WHERE hashtag_id = #{hashtagId}
+        AND store_id = #{storeId}
+    </update>
+
+</mapper>

--- a/src/main/resources/mapper/StoreMapper.xml
+++ b/src/main/resources/mapper/StoreMapper.xml
@@ -16,6 +16,7 @@
             , floor AS floor
             , description AS description
             , avg_score AS avgScore
+            , review_count AS reviewCount
         FROM store
         WHERE id = #{storeId}
     </select>
@@ -32,4 +33,32 @@
         FETCH FIRST 5 ROWS ONLY
     </select>
 
+    <insert id="saveReview" parameterType="com.hyundai.app.store.domain.Review" >
+        INSERT INTO review (
+            id
+            , member_id
+            , store_id
+            , score
+            , content
+        )
+        VALUES (
+            review_id_seq.nextval
+            , #{review.memberId}
+            , #{review.storeId}
+            , #{review.score}
+            , #{review.content}
+        )
+    </insert>
+
+    <update id="updateAvgScore">
+        UPDATE store
+        SET avg_score = #{avgScore}
+        WHERE id = #{storeId}
+    </update>
+
+    <update id="updateReviewCount">
+        UPDATE store
+        SET review_count = review_count + 1
+        WHERE id = #{storeId}
+    </update>
 </mapper>


### PR DESCRIPTION
## 구현 사항

- **리뷰 작성 기능 구현**
  - 별점 평점 업데이트 -> 이를 위해 Review 테이블에 review_count 추가
  - 리뷰 입력 시 별점은 정수로만, 매장 조회 시 별점은 소숫점 1자리까지!
  - 해시 태그 테이블의 count 필드로 해당 매장의 그 해시태그가 몇 개나 있는 지 조회
- **유효성 검증**
  - 별점(정수, 5점 이하)
  - 댓글 내용 5글자 이상
  - 해시태그 존재하지 않는 id 입력 시 에러 반환

<img width="683" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/2a3f095a-7609-4425-9a30-19f498bc4e36">

<img width="529" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/9b652fdf-24f3-4cfa-9fbf-0b4c06c45fb7">


## 참고 사항

+) validate하는 메소드들 일괄적으로 새 파일로 빼버리는 건 어떨 지 고민..ㅎㅎ