### PR TITLE
[HEENDY-33-admin-event-API] 유저용 이벤트 조회, 어드민용 이벤트 조회, 작성 API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -177,6 +177,11 @@
       <version>1.9.13</version>
     </dependency>
     <dependency>
+      <groupId>com.fasterxml.jackson.datatype</groupId>
+      <artifactId>jackson-datatype-jsr310</artifactId>
+      <version>2.12.5</version>
+    </dependency>
+    <dependency>
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
       <version>1.5</version>

--- a/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
@@ -1,12 +1,11 @@
 package com.hyundai.app.event.controller;
 
 import com.hyundai.app.common.AdventureOfHeendyResponse;
+import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventListResDto;
 import com.hyundai.app.event.service.EventService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * @author 엄상은
@@ -24,5 +23,12 @@ public class EventAdminController {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
         return AdventureOfHeendyResponse.success("지점의 이벤트 목록을 가져왔습니다.", eventService.findEventList(storeId));
+    }
+
+    @GetMapping("/{eventId}")
+    public AdventureOfHeendyResponse<EventDetailResDto> find(@PathVariable final int eventId) {
+        // TODO: 지점 ID 받아오는 부분 수정
+        int storeId = 1;
+        return AdventureOfHeendyResponse.success("지점의 이벤트 상세 정보를 가져왔습니다.", eventService.find(storeId, eventId));
     }
 }

--- a/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
@@ -5,6 +5,8 @@ import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventListResDto;
 import com.hyundai.app.event.dto.EventSaveReqDto;
 import com.hyundai.app.event.service.EventService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -13,6 +15,7 @@ import org.springframework.web.bind.annotation.*;
  * @since 2024/02/19
  * 어드민용 이벤트 컨트롤러
  */
+@Api("어드민용 이벤트 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/admin/events")
 @RestController
@@ -20,6 +23,7 @@ public class EventAdminController {
     private final EventService eventService;
 
     @GetMapping
+    @ApiOperation("어드민용 해당 지점 이벤트 전체 조회 API")
     public AdventureOfHeendyResponse<EventListResDto> findEventList() {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
@@ -27,6 +31,7 @@ public class EventAdminController {
     }
 
     @PostMapping
+    @ApiOperation("어드민용 이벤트 작성 API")
     public AdventureOfHeendyResponse<EventDetailResDto> save(@RequestBody EventSaveReqDto eventSaveReqDto) {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
@@ -34,6 +39,7 @@ public class EventAdminController {
     }
 
     @GetMapping("/{eventId}")
+    @ApiOperation("어드민용 이벤트 상세조회 API")
     public AdventureOfHeendyResponse<EventDetailResDto> findEvent(@PathVariable final int eventId) {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;

--- a/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
@@ -3,6 +3,7 @@ package com.hyundai.app.event.controller;
 import com.hyundai.app.common.AdventureOfHeendyResponse;
 import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventListResDto;
+import com.hyundai.app.event.dto.EventSaveReqDto;
 import com.hyundai.app.event.service.EventService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -23,6 +24,13 @@ public class EventAdminController {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
         return AdventureOfHeendyResponse.success("지점의 이벤트 목록을 가져왔습니다.", eventService.findEventList(storeId));
+    }
+
+    @PostMapping
+    public AdventureOfHeendyResponse<EventDetailResDto> save(@RequestBody EventSaveReqDto eventSaveReqDto) {
+        // TODO: 지점 ID 받아오는 부분 수정
+        int storeId = 1;
+        return AdventureOfHeendyResponse.success("이벤트를 저장했습니다.", eventService.save(storeId, eventSaveReqDto));
     }
 
     @GetMapping("/{eventId}")

--- a/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
@@ -34,9 +34,9 @@ public class EventAdminController {
     }
 
     @GetMapping("/{eventId}")
-    public AdventureOfHeendyResponse<EventDetailResDto> find(@PathVariable final int eventId) {
+    public AdventureOfHeendyResponse<EventDetailResDto> findEvent(@PathVariable final int eventId) {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
-        return AdventureOfHeendyResponse.success("지점의 이벤트 상세 정보를 가져왔습니다.", eventService.find(storeId, eventId));
+        return AdventureOfHeendyResponse.success("지점의 이벤트 상세 정보를 가져왔습니다.", eventService.findEvent(storeId, eventId));
     }
 }

--- a/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
@@ -1,0 +1,28 @@
+package com.hyundai.app.event.controller;
+
+import com.hyundai.app.common.AdventureOfHeendyResponse;
+import com.hyundai.app.event.dto.EventListResDto;
+import com.hyundai.app.event.service.EventService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/19
+ * 어드민용 이벤트 컨트롤러
+ */
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/admin/events")
+@RestController
+public class EventAdminController {
+    private final EventService eventService;
+
+    @GetMapping
+    public AdventureOfHeendyResponse<EventListResDto> findEventList() {
+        // TODO: 지점 ID 받아오는 부분 수정
+        int storeId = 1;
+        return AdventureOfHeendyResponse.success("지점의 이벤트 목록을 가져왔습니다.", eventService.findEventList(storeId));
+    }
+}

--- a/src/main/java/com/hyundai/app/event/controller/EventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventController.java
@@ -23,8 +23,7 @@ public class EventController {
     private final EventService eventService;
 
     @GetMapping
-    public AdventureOfHeendyResponse<EventDetailResDto> find(@MemberId Integer memberId,
-                                                             @RequestParam EventType eventType) {
-        return AdventureOfHeendyResponse.success("이벤트 목록을 가져왔습니다.", eventService.find(eventType));
+    public AdventureOfHeendyResponse<EventDetailResDto> findCurrentEventByEventType(@RequestParam EventType eventType) {
+        return AdventureOfHeendyResponse.success("이벤트 목록을 가져왔습니다.", eventService.findCurrentEventByEventType(eventType));
     }
 }

--- a/src/main/java/com/hyundai/app/event/controller/EventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventController.java
@@ -1,0 +1,30 @@
+package com.hyundai.app.event.controller;
+
+import com.hyundai.app.common.AdventureOfHeendyResponse;
+import com.hyundai.app.event.dto.EventDetailResDto;
+import com.hyundai.app.event.enumType.EventType;
+import com.hyundai.app.event.service.EventService;
+import com.hyundai.app.security.methodparam.MemberId;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 사용자용 이벤트 컨트롤러
+ */
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/events")
+@RestController
+public class EventController {
+    private final EventService eventService;
+
+    @GetMapping
+    public AdventureOfHeendyResponse<EventDetailResDto> find(@MemberId Integer memberId,
+                                                             @RequestParam EventType eventType) {
+        return AdventureOfHeendyResponse.success("이벤트 목록을 가져왔습니다.", eventService.find(eventType));
+    }
+}

--- a/src/main/java/com/hyundai/app/event/controller/EventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventController.java
@@ -4,7 +4,8 @@ import com.hyundai.app.common.AdventureOfHeendyResponse;
 import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.enumType.EventType;
 import com.hyundai.app.event.service.EventService;
-import com.hyundai.app.security.methodparam.MemberId;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RestController;
  * @since 2024/02/18
  * 사용자용 이벤트 컨트롤러
  */
+@Api("유저용 이벤트 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/events")
 @RestController
@@ -23,6 +25,7 @@ public class EventController {
     private final EventService eventService;
 
     @GetMapping
+    @ApiOperation("유저용 현재 열린 이벤트 조회 API")
     public AdventureOfHeendyResponse<EventDetailResDto> findCurrentEventByEventType(@RequestParam EventType eventType) {
         return AdventureOfHeendyResponse.success("이벤트 목록을 가져왔습니다.", eventService.findCurrentEventByEventType(eventType));
     }

--- a/src/main/java/com/hyundai/app/event/domain/Event.java
+++ b/src/main/java/com/hyundai/app/event/domain/Event.java
@@ -1,0 +1,27 @@
+package com.hyundai.app.event.domain;
+
+import com.hyundai.app.common.entity.BaseEntity;
+import com.hyundai.app.event.enumType.EventType;
+import com.hyundai.app.event.enumType.RewardType;
+
+import java.time.LocalDate;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 엔티티
+ */
+public class Event extends BaseEntity {
+    private int id;
+    private String title;
+    private String content;
+    private LocalDate startedAt;
+    private LocalDate finishedAt;
+    private int maxCount;
+    private int visitedCount;
+    private EventType eventType;
+    private RewardType rewardType;
+    private String reward;
+    private int isDeleted;
+    private int storeId;
+}

--- a/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
+++ b/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
@@ -1,0 +1,13 @@
+package com.hyundai.app.event.domain;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 활성화 시간 엔티티
+ */
+public class EventActiveTime {
+    private int id;
+    private int eventId;
+    private int opennedAt;
+    private int closedAt;
+}

--- a/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
+++ b/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
@@ -1,13 +1,30 @@
 package com.hyundai.app.event.domain;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
 /**
  * @author 엄상은
  * @since 2024/02/18
  * 이벤트 활성화 시간 엔티티
  */
+@NoArgsConstructor
+@AllArgsConstructor
 public class EventActiveTime {
     private int id;
     private int eventId;
     private int opennedAt;
     private int closedAt;
+
+    @JsonCreator
+    public EventActiveTime(@JsonProperty("opennedAt") int opennedAt, @JsonProperty("closedAt") int closedAt) {
+        this.opennedAt = opennedAt;
+        this.closedAt = closedAt;
+    }
+
+    public void setEventId(int eventId) {
+        this.eventId = eventId;
+    }
 }

--- a/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
+++ b/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
@@ -2,16 +2,14 @@ package com.hyundai.app.event.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 
 /**
  * @author 엄상은
  * @since 2024/02/18
  * 이벤트 활성화 시간 엔티티
  */
-@NoArgsConstructor
-@AllArgsConstructor
+@RequiredArgsConstructor
 public class EventActiveTime {
     private int id;
     private int eventId;

--- a/src/main/java/com/hyundai/app/event/domain/MemberEvent.java
+++ b/src/main/java/com/hyundai/app/event/domain/MemberEvent.java
@@ -1,0 +1,14 @@
+package com.hyundai.app.event.domain;
+
+import com.hyundai.app.common.entity.BaseEntity;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 회원이 참여한 이벤트 엔티티
+ */
+public class MemberEvent extends BaseEntity {
+    private int id;
+    private int eventId;
+    private int memberId;
+}

--- a/src/main/java/com/hyundai/app/event/dto/EventActiveTimeZoneDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventActiveTimeZoneDto.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 /**
  * @author 엄상은
  * @since 2024/02/19
- * (설명)
+ * 이벤트 활성화 시작, 종료 시간 DTO
  */
 @Getter
 @NoArgsConstructor

--- a/src/main/java/com/hyundai/app/event/dto/EventActiveTimeZoneDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventActiveTimeZoneDto.java
@@ -1,0 +1,18 @@
+package com.hyundai.app.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/19
+ * (설명)
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventActiveTimeZoneDto {
+    private int opennedAt;
+    private int closedAt;
+}

--- a/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
@@ -1,5 +1,6 @@
 package com.hyundai.app.event.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.hyundai.app.event.enumType.EventType;
 import com.hyundai.app.event.enumType.RewardType;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDate;
+import java.util.List;
 
 /**
  * @author 엄상은
@@ -24,8 +26,15 @@ public class EventDetailResDto {
     private int storeId;
     private RewardType rewardType;
     private String reward;
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startedAt;
+    @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate finishedAt;
     private int maxCount;
     private int visitedCount;
+    private List<EventActiveTimeZoneDto> eventActiveTimeZoneDto;
+
+    public void setActiveTimeList(List<EventActiveTimeZoneDto> eventActiveTimeZoneDto) {
+        this.eventActiveTimeZoneDto = eventActiveTimeZoneDto;
+    }
 }

--- a/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
@@ -6,6 +6,8 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDate;
+
 /**
  * @author 엄상은
  * @since 2024/02/18
@@ -22,4 +24,8 @@ public class EventDetailResDto {
     private int storeId;
     private RewardType rewardType;
     private String reward;
+    private LocalDate startedAt;
+    private LocalDate finishedAt;
+    private int maxCount;
+    private int visitedCount;
 }

--- a/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
@@ -1,0 +1,25 @@
+package com.hyundai.app.event.dto;
+
+import com.hyundai.app.event.enumType.EventType;
+import com.hyundai.app.event.enumType.RewardType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 상세 조회 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventDetailResDto {
+    private int id;
+    private String title;
+    private String content;
+    private EventType eventType;
+    private int storeId;
+    private RewardType rewardType;
+    private String reward;
+}

--- a/src/main/java/com/hyundai/app/event/dto/EventListResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventListResDto.java
@@ -16,4 +16,8 @@ import java.util.List;
 @AllArgsConstructor
 public class EventListResDto {
     private List<EventDetailResDto> events;
+
+    public static EventListResDto of(List<EventDetailResDto> eventDetailResDtoList) {
+        return new EventListResDto(eventDetailResDtoList);
+    }
 }

--- a/src/main/java/com/hyundai/app/event/dto/EventListResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventListResDto.java
@@ -1,0 +1,19 @@
+package com.hyundai.app.event.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 전체 정보 조회 응답 객체
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class EventListResDto {
+    private List<EventDetailResDto> events;
+}

--- a/src/main/java/com/hyundai/app/event/dto/EventSaveReqDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventSaveReqDto.java
@@ -1,0 +1,42 @@
+package com.hyundai.app.event.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.hyundai.app.event.domain.EventActiveTime;
+import com.hyundai.app.event.enumType.EventType;
+import com.hyundai.app.event.enumType.RewardType;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/19
+ * 이벤트 저장 요청 객체
+ */
+@Getter
+public class EventSaveReqDto {
+    private int id;
+    private String title;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate startedAt;
+    @JsonFormat(pattern = "yyyy-MM-dd")
+    private LocalDate finishedAt;
+    private List<EventActiveTime> activeTimeList;
+    private int maxCount;
+    private EventType eventType;
+    private RewardType rewardType;
+    private String reward;
+    private String content;
+    private int storeId;
+
+    public void setDefaultActiveTimeIfEmpty() {
+        if (this.activeTimeList == null || this.activeTimeList.isEmpty()) {
+            this.activeTimeList = List.of(new EventActiveTime(10, 22));
+        }
+    }
+
+    public void setStoreId(int storeId) {
+        this.storeId = storeId;
+    }
+}

--- a/src/main/java/com/hyundai/app/event/enumType/EventType.java
+++ b/src/main/java/com/hyundai/app/event/enumType/EventType.java
@@ -1,0 +1,19 @@
+package com.hyundai.app.event.enumType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 타입 ENUM 객체
+ */
+@Getter
+@AllArgsConstructor
+public enum EventType {
+    CAFE("카페"),
+    RESTAURANT("식당"),
+    SHOPPING("쇼핑");
+
+    private final String description;
+}

--- a/src/main/java/com/hyundai/app/event/enumType/RewardType.java
+++ b/src/main/java/com/hyundai/app/event/enumType/RewardType.java
@@ -1,0 +1,23 @@
+package com.hyundai.app.event.enumType;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 보상 타입 ENUM 객체
+ */
+@Getter
+@AllArgsConstructor
+public enum RewardType {
+    COUPON("COUPON"),
+    DISCOUNT("DISCOUNT"),
+    STAMP("STAMP"),
+    POINT("POINT"),
+    GIFT("GIFT"),
+    EVENT("EVENT"),
+    ETC("ETC");
+
+    private final String description;
+}

--- a/src/main/java/com/hyundai/app/event/mapper/EventActiveTimeMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventActiveTimeMapper.java
@@ -1,7 +1,10 @@
 package com.hyundai.app.event.mapper;
 
 import com.hyundai.app.event.domain.EventActiveTime;
+import com.hyundai.app.event.dto.EventActiveTimeZoneDto;
 import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
 
 /**
  * @author 엄상은
@@ -11,5 +14,5 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface EventActiveTimeMapper {
     int save(EventActiveTime eventActiveTime);
-
+    List<EventActiveTimeZoneDto> findByEventId(int eventId);
 }

--- a/src/main/java/com/hyundai/app/event/mapper/EventActiveTimeMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventActiveTimeMapper.java
@@ -1,0 +1,15 @@
+package com.hyundai.app.event.mapper;
+
+import com.hyundai.app.event.domain.EventActiveTime;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/19
+ * 이벤트 활성화 시간 MAPPER
+ */
+@Mapper
+public interface EventActiveTimeMapper {
+    int save(EventActiveTime eventActiveTime);
+
+}

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -1,0 +1,15 @@
+package com.hyundai.app.event.mapper;
+
+import com.hyundai.app.event.dto.EventDetailResDto;
+import com.hyundai.app.event.enumType.EventType;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 Mapper
+ */
+@Mapper
+public interface EventMapper {
+    EventDetailResDto find(EventType eventType);
+}

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -16,4 +16,6 @@ public interface EventMapper {
     EventDetailResDto find(EventType eventType);
 
     List<EventDetailResDto> findEventList(int storeId);
+
+    EventDetailResDto findById(int eventId);
 }

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -4,6 +4,8 @@ import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.enumType.EventType;
 import org.apache.ibatis.annotations.Mapper;
 
+import java.util.List;
+
 /**
  * @author 엄상은
  * @since 2024/02/18
@@ -12,4 +14,6 @@ import org.apache.ibatis.annotations.Mapper;
 @Mapper
 public interface EventMapper {
     EventDetailResDto find(EventType eventType);
+
+    List<EventDetailResDto> findEventList(int storeId);
 }

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -14,7 +14,7 @@ import java.util.List;
  */
 @Mapper
 public interface EventMapper {
-    EventDetailResDto find(EventType eventType);
+    EventDetailResDto findCurrentEventByEventType(EventType eventType);
 
     List<EventDetailResDto> findEventList(int storeId);
 

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -1,6 +1,7 @@
 package com.hyundai.app.event.mapper;
 
 import com.hyundai.app.event.dto.EventDetailResDto;
+import com.hyundai.app.event.dto.EventSaveReqDto;
 import com.hyundai.app.event.enumType.EventType;
 import org.apache.ibatis.annotations.Mapper;
 
@@ -18,4 +19,6 @@ public interface EventMapper {
     List<EventDetailResDto> findEventList(int storeId);
 
     EventDetailResDto findById(int eventId);
+
+    int save(EventSaveReqDto eventSaveReqDto);
 }

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -40,8 +40,7 @@ public class EventService {
             eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDtoList);
         }
 
-        EventListResDto eventListResDto = new EventListResDto(eventDetailResDtoList);
-
+        EventListResDto eventListResDto = EventListResDto.of(eventDetailResDtoList);
         return eventListResDto;
     }
 

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -2,7 +2,9 @@ package com.hyundai.app.event.service;
 
 import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventListResDto;
+import com.hyundai.app.event.dto.EventSaveReqDto;
 import com.hyundai.app.event.enumType.EventType;
+import com.hyundai.app.event.mapper.EventActiveTimeMapper;
 import com.hyundai.app.event.mapper.EventMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -18,6 +20,7 @@ import java.util.List;
 @Service
 public class EventService {
     private final EventMapper eventMapper;
+    private final EventActiveTimeMapper eventActiveTimeMapper;
 
     public EventDetailResDto find(EventType eventType) {
         return eventMapper.find(eventType);
@@ -38,5 +41,26 @@ public class EventService {
             throw new IllegalArgumentException("해당 지점의 이벤트가 아닙니다.");
         }
         return eventDetailResDto;
+    }
+
+    public EventDetailResDto save(int storeId, EventSaveReqDto eventSaveReqDto) {
+        int eventId = saveEvent(storeId, eventSaveReqDto);
+        saveEventActiveTime(eventId, eventSaveReqDto);
+        return find(storeId, eventId);
+    }
+
+    public int saveEvent(int storeId, EventSaveReqDto eventSaveReqDto) {
+        eventSaveReqDto.setStoreId(storeId);
+        eventMapper.save(eventSaveReqDto);
+        int eventId = eventSaveReqDto.getId();
+        return eventId;
+    }
+
+    public void saveEventActiveTime(int eventId, EventSaveReqDto eventSaveReqDto) {
+        eventSaveReqDto.setDefaultActiveTimeIfEmpty();
+        eventSaveReqDto.getActiveTimeList().forEach(eventActiveTime -> {
+            eventActiveTime.setEventId(eventId);
+            eventActiveTimeMapper.save(eventActiveTime);
+        });
     }
 }

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -57,7 +57,7 @@ public class EventService {
         return eventDetailResDto;
     }
 
-    public List<EventActiveTimeZoneDto> findEventActiveTime(int eventId) {
+    private List<EventActiveTimeZoneDto> findEventActiveTime(int eventId) {
         List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = eventActiveTimeMapper.findByEventId(eventId);
         return eventActiveTimeZoneDto;
     }
@@ -68,14 +68,14 @@ public class EventService {
         return find(storeId, eventId);
     }
 
-    public int saveEvent(int storeId, EventSaveReqDto eventSaveReqDto) {
+    private int saveEvent(int storeId, EventSaveReqDto eventSaveReqDto) {
         eventSaveReqDto.setStoreId(storeId);
         eventMapper.save(eventSaveReqDto);
         int eventId = eventSaveReqDto.getId();
         return eventId;
     }
 
-    public void saveEventActiveTime(int eventId, EventSaveReqDto eventSaveReqDto) {
+    private void saveEventActiveTime(int eventId, EventSaveReqDto eventSaveReqDto) {
         eventSaveReqDto.setDefaultActiveTimeIfEmpty();
         eventSaveReqDto.getActiveTimeList().forEach(eventActiveTime -> {
             eventActiveTime.setEventId(eventId);

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -1,10 +1,13 @@
 package com.hyundai.app.event.service;
 
 import com.hyundai.app.event.dto.EventDetailResDto;
+import com.hyundai.app.event.dto.EventListResDto;
 import com.hyundai.app.event.enumType.EventType;
 import com.hyundai.app.event.mapper.EventMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * @author 엄상은
@@ -18,5 +21,11 @@ public class EventService {
 
     public EventDetailResDto find(EventType eventType) {
         return eventMapper.find(eventType);
+    }
+
+    public EventListResDto findEventList(int storeId) {
+        List<EventDetailResDto> eventDetailResDto = eventMapper.findEventList(storeId);
+        EventListResDto eventListResDto = new EventListResDto(eventDetailResDto);
+        return eventListResDto;
     }
 }

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -1,5 +1,6 @@
 package com.hyundai.app.event.service;
 
+import com.hyundai.app.event.dto.EventActiveTimeZoneDto;
 import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventListResDto;
 import com.hyundai.app.event.dto.EventSaveReqDto;
@@ -23,12 +24,23 @@ public class EventService {
     private final EventActiveTimeMapper eventActiveTimeMapper;
 
     public EventDetailResDto find(EventType eventType) {
-        return eventMapper.find(eventType);
+        EventDetailResDto eventDetailResDto = eventMapper.find(eventType);
+        int eventId = eventDetailResDto.getId();
+        List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = findEventActiveTime(eventId);
+        eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDto);
+        return eventDetailResDto;
     }
 
     public EventListResDto findEventList(int storeId) {
-        List<EventDetailResDto> eventDetailResDto = eventMapper.findEventList(storeId);
-        EventListResDto eventListResDto = new EventListResDto(eventDetailResDto);
+        List<EventDetailResDto> eventDetailResDtoList = eventMapper.findEventList(storeId);
+
+        for (EventDetailResDto eventDetailResDto : eventDetailResDtoList) {
+            int eventId = eventDetailResDto.getId();
+            List<EventActiveTimeZoneDto> eventActiveTimeZoneDtoList = findEventActiveTime(eventId);
+            eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDtoList);
+        }
+
+        EventListResDto eventListResDto = new EventListResDto(eventDetailResDtoList);
         return eventListResDto;
     }
 
@@ -40,7 +52,14 @@ public class EventService {
         else if (eventDetailResDto.getStoreId() != storeId) {
             throw new IllegalArgumentException("해당 지점의 이벤트가 아닙니다.");
         }
+        List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = findEventActiveTime(eventId);
+        eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDto);
         return eventDetailResDto;
+    }
+
+    public List<EventActiveTimeZoneDto> findEventActiveTime(int eventId) {
+        List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = eventActiveTimeMapper.findByEventId(eventId);
+        return eventActiveTimeZoneDto;
     }
 
     public EventDetailResDto save(int storeId, EventSaveReqDto eventSaveReqDto) {

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -15,7 +15,7 @@ import java.util.List;
 /**
  * @author 엄상은
  * @since 2024/02/18
- * 이벤트 서비스
+ * 사용자용 + 어드민용 이벤트 서비스
  */
 @RequiredArgsConstructor
 @Service
@@ -23,8 +23,8 @@ public class EventService {
     private final EventMapper eventMapper;
     private final EventActiveTimeMapper eventActiveTimeMapper;
 
-    public EventDetailResDto find(EventType eventType) {
-        EventDetailResDto eventDetailResDto = eventMapper.find(eventType);
+    public EventDetailResDto findCurrentEventByEventType(EventType eventType) {
+        EventDetailResDto eventDetailResDto = eventMapper.findCurrentEventByEventType(eventType);
         int eventId = eventDetailResDto.getId();
         List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = findEventActiveTime(eventId);
         eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDto);
@@ -41,15 +41,16 @@ public class EventService {
         }
 
         EventListResDto eventListResDto = new EventListResDto(eventDetailResDtoList);
+
         return eventListResDto;
     }
 
-    public EventDetailResDto find(int storeId, int eventId) {
+    public EventDetailResDto findEvent(int storeId, int eventId) {
         EventDetailResDto eventDetailResDto = eventMapper.findById(eventId);
         if (eventDetailResDto == null) {
             throw new IllegalArgumentException("해당 이벤트가 존재하지 않습니다.");
         }
-        else if (eventDetailResDto.getStoreId() != storeId) {
+        if (eventDetailResDto.getStoreId() != storeId) {
             throw new IllegalArgumentException("해당 지점의 이벤트가 아닙니다.");
         }
         List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = findEventActiveTime(eventId);
@@ -65,7 +66,7 @@ public class EventService {
     public EventDetailResDto save(int storeId, EventSaveReqDto eventSaveReqDto) {
         int eventId = saveEvent(storeId, eventSaveReqDto);
         saveEventActiveTime(eventId, eventSaveReqDto);
-        return find(storeId, eventId);
+        return findEvent(storeId, eventId);
     }
 
     private int saveEvent(int storeId, EventSaveReqDto eventSaveReqDto) {

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -1,0 +1,22 @@
+package com.hyundai.app.event.service;
+
+import com.hyundai.app.event.dto.EventDetailResDto;
+import com.hyundai.app.event.enumType.EventType;
+import com.hyundai.app.event.mapper.EventMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/18
+ * 이벤트 서비스
+ */
+@RequiredArgsConstructor
+@Service
+public class EventService {
+    private final EventMapper eventMapper;
+
+    public EventDetailResDto find(EventType eventType) {
+        return eventMapper.find(eventType);
+    }
+}

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -28,4 +28,15 @@ public class EventService {
         EventListResDto eventListResDto = new EventListResDto(eventDetailResDto);
         return eventListResDto;
     }
+
+    public EventDetailResDto find(int storeId, int eventId) {
+        EventDetailResDto eventDetailResDto = eventMapper.findById(eventId);
+        if (eventDetailResDto == null) {
+            throw new IllegalArgumentException("해당 이벤트가 존재하지 않습니다.");
+        }
+        else if (eventDetailResDto.getStoreId() != storeId) {
+            throw new IllegalArgumentException("해당 지점의 이벤트가 아닙니다.");
+        }
+        return eventDetailResDto;
+    }
 }

--- a/src/main/java/com/hyundai/app/friend/controller/FriendController.java
+++ b/src/main/java/com/hyundai/app/friend/controller/FriendController.java
@@ -6,6 +6,8 @@ import com.hyundai.app.friend.dto.MbtiSaveReqDto;
 import com.hyundai.app.friend.dto.FriendListResDto;
 import com.hyundai.app.friend.service.FriendService;
 import com.hyundai.app.security.methodparam.MemberId;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -16,6 +18,7 @@ import javax.validation.Valid;
  * @since 2024/02/09
  * 친구 관련 API
  */
+@Api("친구 관련 API")
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/friends")
 @RestController
@@ -24,17 +27,20 @@ public class FriendController {
     private final FriendService friendService;
 
     @GetMapping
+    @ApiOperation("전체 친구 리스트 조회 API")
     public AdventureOfHeendyResponse<FriendListResDto> findFriendList(@MemberId Integer memberId) {
         return AdventureOfHeendyResponse.success("친구 목록을 가져왔습니다.", friendService.findFriendList(memberId));
     }
 
     @GetMapping("/{friendId}")
+    @ApiOperation("특정 친구 조회 API")
     public AdventureOfHeendyResponse<FriendDetailResDto> find(@MemberId Integer memberId,
                                                               @PathVariable final int friendId) {
         return AdventureOfHeendyResponse.success("친구 흰디에 방문했습니다.", friendService.findFriend(memberId, friendId));
     }
 
     @PostMapping("/{friendId}/mbti")
+    @ApiOperation("친구 MBTI 작성 API")
     public AdventureOfHeendyResponse<String> saveMbti(@MemberId Integer memberId,
                                                       @PathVariable final int friendId,
                                                       @Valid @RequestBody final MbtiSaveReqDto mbtiSaveReqDto) {

--- a/src/main/java/com/hyundai/app/friend/service/FriendService.java
+++ b/src/main/java/com/hyundai/app/friend/service/FriendService.java
@@ -54,11 +54,11 @@ public class FriendService {
                 .build();
     }
 
-    public MemberConnection findConnection(FriendDto friendDto) {
+    private MemberConnection findConnection(FriendDto friendDto) {
         return friendMapper.findConnection(friendDto);
     }
 
-    public void saveConnection(FriendDto friendDto) {
+    private void saveConnection(FriendDto friendDto) {
         MemberConnection originMemberConnection = new MemberConnection(
                 friendDto.getMemberId(),
                 friendDto.getFriendId()
@@ -75,7 +75,7 @@ public class FriendService {
         }
     }
 
-    public Boolean isFriend(FriendDto friendDto) {
+    private Boolean isFriend(FriendDto friendDto) {
         if (memberMapper.findById(friendDto.getFriendId()) == null) {
             throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
         }
@@ -85,7 +85,7 @@ public class FriendService {
         return true;
     }
 
-    public String findMbtiByFriend(FriendDto friendDto) {
+    private String findMbtiByFriend(FriendDto friendDto) {
         return mbtiMapper.findMbtiByFriend(friendDto);
     }
 
@@ -102,7 +102,7 @@ public class FriendService {
         return findMbtiByFriend(new FriendDto(memberId, friendId));
     }
 
-    public GameStatus findGameStatus(FriendDto friendDto){
+    private GameStatus findGameStatus(FriendDto friendDto){
         GameStatus gameStatus = gameMapper.findGameStatus(friendDto);
         return gameStatus;
     }

--- a/src/main/resources/mapper/EventActiveTimeMapper.xml
+++ b/src/main/resources/mapper/EventActiveTimeMapper.xml
@@ -14,4 +14,11 @@
                , #{opennedAt}
                , #{closedAt})
     </insert>
+
+    <select id="findByEventId" parameterType="int" resultType="eventactivetimezonedto">
+        SELECT  openned_at
+                , closed_at
+        FROM    event_active_time
+        WHERE   event_id = #{eventId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/EventActiveTimeMapper.xml
+++ b/src/main/resources/mapper/EventActiveTimeMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hyundai.app.event.mapper.EventActiveTimeMapper">
+    <!--    @author 엄상은  -->
+    <!--    @since 2024/02/19  -->
+    <!--    이벤트 활성화 시간대 mapper  -->
+    <insert id="save" parameterType="eventactivetime">
+        INSERT  INTO event_active_time (event_id
+                                      , openned_at
+                                      , closed_at)
+        VALUES  (#{eventId}
+               , #{opennedAt}
+               , #{closedAt})
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hyundai.app.event.mapper.EventMapper">
+    <!--    @author 엄상은  -->
+    <!--    @since 2024/02/18  -->
+    <!--    이벤트 mapper  -->
+    <select id="find" parameterType="eventtype" resultType="eventdetailresdto">
+        SELECT  id
+                , title
+                , content
+                , event_type
+                , store_id
+                , reward_type
+                , reward
+        FROM    event
+        WHERE   sysdate BETWEEN started_at AND finished_at
+        AND     id  IN  (SELECT event_id
+                        FROM    event_active_time
+                        WHERE   TO_NUMBER(TO_CHAR(sysdate, 'HH24')) BETWEEN openned_at AND closed_at)
+        AND     (#{eventType} IS NULL OR event_type = #{eventType})
+        AND     max_count >= visited_count
+        AND     is_deleted = 0
+        FETCH   FIRST 1 ROWS ONLY
+    </select>
+</mapper>

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -54,4 +54,29 @@
         FROM    event
         WHERE   id = #{eventId}
     </select>
+
+    <insert id="save" parameterType="eventsavereqdto">
+        INSERT  INTO event (title
+                           , started_at
+                           , finished_at
+                           , max_count
+                           , event_type
+                           , store_id
+                           , reward_type
+                           , reward
+                           , content)
+        VALUES  (#{title}
+                , #{startedAt}
+                , #{finishedAt}
+                , #{maxCount}
+                , #{eventType}
+                , #{storeId}
+                , #{rewardType}
+                , #{reward}
+                , #{content})
+        <selectKey keyProperty="id" resultType="int" order="AFTER">
+            SELECT  MAX(id)
+            FROM    event
+        </selectKey>
+    </insert>
 </mapper>

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -38,4 +38,20 @@
         WHERE   store_id = #{storeId}
         AND     is_deleted = 0
     </select>
+
+    <select id="findById" resultType="eventdetailresdto">
+        SELECT  id
+                , title
+                , content
+                , event_type
+                , store_id
+                , reward_type
+                , reward
+                , started_at
+                , finished_at
+                , max_count
+                , visited_count
+        FROM    event
+        WHERE   id = #{eventId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -24,4 +24,18 @@
         AND     is_deleted = 0
         FETCH   FIRST 1 ROWS ONLY
     </select>
+
+    <select id="findEventList" resultType="eventdetailresdto">
+        SELECT  id
+                , title
+                , event_type
+                , started_at
+                , finished_at
+                , reward_type
+                , max_count
+                , visited_count
+        FROM    event
+        WHERE   store_id = #{storeId}
+        AND     is_deleted = 0
+    </select>
 </mapper>

--- a/src/main/resources/mybatis-config.xml
+++ b/src/main/resources/mybatis-config.xml
@@ -5,6 +5,7 @@
 <configuration>
     <settings>
         <setting name="mapUnderscoreToCamelCase" value="true"/>
+        <setting name="jdbcTypeForNull" value="NULL" />
     </settings>
     <typeAliases>
         <package name="com.hyundai.app"/>


### PR DESCRIPTION
## 구현 사항
- 유저용 이벤트 조회 (GET /api/v1/events)
- 어드민용 이벤트 조회 (GET /api/v1/admin/events)
- 어드민용 이벤트 작성 (POST /api/v1/admin/events)
- 어드민용 이벤트 상세 조회 (GET /api/v1/admin/events/{eventId})

## 관련 이슈
[Jira 33번 이슈](https://sooyoung.atlassian.net/jira/software/projects/HEENDY/boards/1?selectedIssue=HEENDY-33)

## TODO
- [ ] 어드민 로그인 이후 storeId 받아오는 작업 refactor
- [x] 이벤트 조회 및 상세조회 시 활성화 시간대 함께 받아오도록 refactor
- [x] startedAt, finishedAt 리턴 시 파싱 refactor
- [ ] 어드민용 이벤트 수정 API

## 아쉬운 점
Insert 이후 자동 생성된 id를 가져오는 과정에서 select after로 max(id)를 가져오도록 설정함.
Mybatis에서 기본 insert문의 리턴으로 1 또는 0 (성공여부) 만을 허용하고 있고, 다른 방법 (useGeneratedKey)을 이용하려고 했으나 Oracle에서 지원하지 않음.
시퀀스를 먼저 select하는 방법도 있었으나 공용 RDS 구축 이전이고 팀 내 네이밍룰이 정착되지 않은 상태라 보류함.

## POSTMAN 스크린샷
### 유저용 이벤트 조회 (GET /api/v1/events)
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/edb466f7-2e8d-4216-a996-15a9d35ecb36)

### 어드민용 이벤트 조회 (GET /api/v1/admin/events)
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/aacc43b7-6916-4611-956a-36d265337435)

### 어드민용 이벤트 작성 (POST /api/v1/admin/events)
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/92464cf9-3c45-45ee-97d7-3cced023a11e)

### 어드민용 이벤트 상세 조회 (GET /api/v1/admin/events/{eventId})
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/62bb7f96-384b-427d-8efe-fa15ab7e5628)

## API 응답 text
### 어드민용 지점 이벤트 전체 조회
```
{
    "success": true,
    "message": "지점의 이벤트 목록을 가져왔습니다.",
    "data": {
        "events": [
            {
                "id": 1,
                "title": "지금 스케쳐스로 가볼까?",
                "content": null,
                "eventType": "SHOPPING",
                "storeId": 0,
                "rewardType": "DISCOUNT",
                "reward": null,
                "startedAt": "2024-02-18",
                "finishedAt": "2024-02-25",
                "maxCount": 100,
                "visitedCount": 0,
                "eventActiveTimeZoneDto": [
                    {
                        "opennedAt": 0,
                        "closedAt": 24
                    }
                ]
            },
            {
                "id": 12,
                "title": "새로운 이벤트 등록",
                "content": null,
                "eventType": "CAFE",
                "storeId": 0,
                "rewardType": "COUPON",
                "reward": null,
                "startedAt": "2023-12-05",
                "finishedAt": "2024-04-05",
                "maxCount": 30,
                "visitedCount": 0,
                "eventActiveTimeZoneDto": [
                    {
                        "opennedAt": 13,
                        "closedAt": 18
                    },
                    {
                        "opennedAt": 20,
                        "closedAt": 23
                    }
                ]
            },
                        {
                "id": 5,
                "title": "새로운 이벤트 등록",
                "content": null,
                "eventType": "CAFE",
                "storeId": 0,
                "rewardType": "COUPON",
                "reward": null,
                "startedAt": "2023-12-05",
                "finishedAt": "2024-04-05",
                "maxCount": 30,
                "visitedCount": 0,
                "eventActiveTimeZoneDto": [
                    {
                        "opennedAt": 10,
                        "closedAt": 22
                    }
                ]
            }
        ]
    }
}
```

## 백엔드 구현 시 참고자료
- [(Jackson) LocalDate, LocalTime, LocalDateTime - Deserialize](https://codediver.tistory.com/128)
- [[Spring] Jackson을 통한 LocalDateTime 맵핑시 deserialize 에러](https://blog.naver.com/writer0713/221615276956)