### PR TITLE
[HEENDY-36-admin-event-UD] 이벤트 수정, 삭제 API

### DIFF
--- a/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventAdminController.java
@@ -43,6 +43,22 @@ public class EventAdminController {
     public AdventureOfHeendyResponse<EventDetailResDto> findEvent(@PathVariable final int eventId) {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
-        return AdventureOfHeendyResponse.success("지점의 이벤트 상세 정보를 가져왔습니다.", eventService.findEvent(storeId, eventId));
+        return AdventureOfHeendyResponse.success("지점의 이벤트 상세 정보를 가져왔습니다.", eventService.find(storeId, eventId));
+    }
+
+    @PatchMapping("/{eventId}")
+    @ApiOperation("어드민용 이벤트 수정 API")
+    public AdventureOfHeendyResponse<EventSaveReqDto> update(@PathVariable final int eventId, @RequestBody EventSaveReqDto eventSaveReqDto) {
+        // TODO: 지점 ID 받아오는 부분 수정
+        int storeId = 1;
+        return AdventureOfHeendyResponse.success("이벤트를 수정했습니다.", eventService.update(storeId, eventId, eventSaveReqDto));
+    }
+
+    @DeleteMapping("/{eventId}")
+    @ApiOperation("어드민용 이벤트 삭제 API")
+    public AdventureOfHeendyResponse<Void> delete(@PathVariable final int eventId) {
+        // TODO: 지점 ID 받아오는 부분 수정
+        int storeId = 1;
+        return AdventureOfHeendyResponse.success("이벤트를 삭제했습니다.", eventService.delete(storeId, eventId));
     }
 }

--- a/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
+++ b/src/main/java/com/hyundai/app/event/domain/EventActiveTime.java
@@ -2,6 +2,7 @@ package com.hyundai.app.event.domain;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 /**
@@ -9,6 +10,7 @@ import lombok.RequiredArgsConstructor;
  * @since 2024/02/18
  * 이벤트 활성화 시간 엔티티
  */
+@Getter
 @RequiredArgsConstructor
 public class EventActiveTime {
     private int id;

--- a/src/main/java/com/hyundai/app/event/dto/EventSaveReqDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventSaveReqDto.java
@@ -36,6 +36,10 @@ public class EventSaveReqDto {
         }
     }
 
+    public void setId(int eventId) {
+        this.id = eventId;
+    }
+
     public void setStoreId(int storeId) {
         this.storeId = storeId;
     }

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -21,4 +21,8 @@ public interface EventMapper {
     EventDetailResDto findById(int eventId);
 
     int save(EventSaveReqDto eventSaveReqDto);
+
+    void update(EventSaveReqDto eventSaveReqDto);
+
+    void delete(int eventId);
 }

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -44,7 +44,14 @@ public class EventService {
         return eventListResDto;
     }
 
-    public EventDetailResDto findEvent(int storeId, int eventId) {
+    public EventDetailResDto find(int storeId, int eventId) {
+        EventDetailResDto eventDetailResDto = findEventAndValidate(storeId, eventId);
+        List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = findEventActiveTime(eventId);
+        eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDto);
+        return eventDetailResDto;
+    }
+
+    public EventDetailResDto findEventAndValidate(int storeId, int eventId) {
         EventDetailResDto eventDetailResDto = eventMapper.findById(eventId);
         if (eventDetailResDto == null) {
             throw new IllegalArgumentException("해당 이벤트가 존재하지 않습니다.");
@@ -65,7 +72,7 @@ public class EventService {
     public EventDetailResDto save(int storeId, EventSaveReqDto eventSaveReqDto) {
         int eventId = saveEvent(storeId, eventSaveReqDto);
         saveEventActiveTime(eventId, eventSaveReqDto);
-        return findEvent(storeId, eventId);
+        return find(storeId, eventId);
     }
 
     private int saveEvent(int storeId, EventSaveReqDto eventSaveReqDto) {
@@ -81,5 +88,18 @@ public class EventService {
             eventActiveTime.setEventId(eventId);
             eventActiveTimeMapper.save(eventActiveTime);
         });
+    }
+
+    public EventSaveReqDto update(int storeId, int eventId, EventSaveReqDto eventSaveReqDto) {
+        findEventAndValidate(storeId, eventId);
+        eventSaveReqDto.setId(eventId);
+        eventMapper.update(eventSaveReqDto);
+        return eventSaveReqDto;
+    }
+
+    public Void delete(int storeId, int eventId) {
+        findEventAndValidate(storeId, eventId);
+        eventMapper.delete(eventId);
+        return null;
     }
 }

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -6,7 +6,7 @@
     <!--    @author 엄상은  -->
     <!--    @since 2024/02/18  -->
     <!--    이벤트 mapper  -->
-    <select id="find" parameterType="eventtype" resultType="eventdetailresdto">
+    <select id="findCurrentEventByEventType" parameterType="eventtype" resultType="eventdetailresdto">
         SELECT  id
                 , title
                 , content

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -79,4 +79,23 @@
             FROM    event
         </selectKey>
     </insert>
+
+    <update id="update" parameterType="eventsavereqdto">
+        UPDATE  event
+        SET     title = #{title}
+                , started_at = #{startedAt}
+                , finished_at = #{finishedAt}
+                , max_count = #{maxCount}
+                , event_type = #{eventType}
+                , reward_type = #{rewardType}
+                , reward = #{reward}
+                , content = #{content}
+        WHERE   id = #{id}
+    </update>
+
+    <delete id="delete">
+        UPDATE  event
+        SET     is_deleted = 1
+        WHERE   id = #{eventId}
+    </delete>
 </mapper>

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -90,12 +90,14 @@
                 , reward_type = #{rewardType}
                 , reward = #{reward}
                 , content = #{content}
+                , updated_at = SYSDATE
         WHERE   id = #{id}
     </update>
 
     <delete id="delete">
         UPDATE  event
         SET     is_deleted = 1
+                , updated_at = SYSDATE
         WHERE   id = #{eventId}
     </delete>
 </mapper>

--- a/src/main/resources/mapper/FriendMapper.xml
+++ b/src/main/resources/mapper/FriendMapper.xml
@@ -40,7 +40,7 @@
     <update id="updateMbti" parameterType="memberconnection">
         UPDATE  member_connection
         SET     mbti_id = #{mbtiId}
-                , updated_at = sysdate
+                , updated_at = SYSDATE
         WHERE   from_member_id = #{fromMemberId}
         AND     to_member_id = #{toMemberId}
     </update>


### PR DESCRIPTION
## 구현 사항
- 어드민용 이벤트 수정 (PATCH /api/v1/admin/event/{eventId})
- 어드민용 이벤트 삭제 (DELETE /api/v1/admin/event/{eventId})

## 관련 이슈
[Jira 36번 이슈](https://sooyoung.atlassian.net/browse/HEENDY-36?atlOrigin=eyJpIjoiNzlmMTNmYmJlYjZhNDJmMmJjN2M3YzMzZmNiYzM0MmUiLCJwIjoiaiJ9)

## POSTMAN 스크린샷
### 이벤트 수정
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/6dec341c-77be-4586-ad31-8e72acaa75e5)

### 이벤트 삭제
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/f8f8d69f-df19-48e7-84a7-cd2fea3fb02c)

## 참고 사항
- 이벤트 삭제 시 soft delete, 이벤트 활성화 시간대 데이터는 따로 삭제하지 않음 (삭제할 필요성이 없다고 판단)
- 이벤트 삭제 시 data null로 반환

