### PR TITLE
[HEENDY 27 fcm push] FCM 푸시 알림 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,4 @@ build/
 .DS_Store
 
 .idea
+**/resources/fcm/fcm-key.json

--- a/pom.xml
+++ b/pom.xml
@@ -293,6 +293,17 @@
       <artifactId>hibernate-validator-annotation-processor</artifactId>
       <version>6.0.13.Final</version>
     </dependency>
+    <dependency>
+      <groupId>com.google.firebase</groupId>
+      <artifactId>firebase-admin</artifactId>
+      <version>9.2.0</version>
+    </dependency>
+      <dependency>
+          <groupId>org.testng</groupId>
+          <artifactId>testng</artifactId>
+          <version>RELEASE</version>
+          <scope>compile</scope>
+      </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/hyundai/app/config/FcmConfig.java
+++ b/src/main/java/com/hyundai/app/config/FcmConfig.java
@@ -1,0 +1,48 @@
+package com.hyundai.app.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import lombok.extern.log4j.Log4j;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
+
+import javax.annotation.PostConstruct;
+import java.io.IOException;
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * Firebase 설정용
+ */
+@Log4j
+@Configuration
+public class FcmConfig {
+    private FirebaseApp firebaseApp;
+    @PostConstruct
+    public void firebaseInit() throws IOException {
+        List<FirebaseApp> firebaseApps = FirebaseApp.getApps();
+        FirebaseApp firebaseApp;
+        if (firebaseApps != null && !firebaseApps.isEmpty()) {
+            log.info("Firebase가 이미 초기화되어있습니다.");
+            for (FirebaseApp app : firebaseApps) {
+                if(app.getName().equals(FirebaseApp.DEFAULT_APP_NAME)) {
+                    this.firebaseApp = app;
+                }
+            }
+        } else {
+            log.info("Firebase를 초기화합니다.");
+            FirebaseOptions options = FirebaseOptions.builder()
+                    .setCredentials(GoogleCredentials.fromStream(new ClassPathResource("fcm/fcm-key.json").getInputStream()))
+                    .build();
+            this.firebaseApp = FirebaseApp.initializeApp(options);
+        }
+    }
+
+    @Bean
+    public FirebaseApp firebaseApp() {
+        return firebaseApp;
+    }
+}

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -36,11 +36,9 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers(
-                "/resources/**",
+                "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/",
-                "/swagger-ui.html"
-                , "/api/v1/auth/**");
+                "/api/v1/auth/**", "/api/v1/fcm/**");
     }
 
     @Override
@@ -62,6 +60,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                     .authorizeRequests()
                     .antMatchers("/api/v1/auth/**").permitAll()
+                    .antMatchers("/api/v1/fcm/**").permitAll()
                     .antMatchers("/api/v1/stores/**").authenticated()
                     .antMatchers("/api/v1/members/**").authenticated()
                     .anyRequest().permitAll()

--- a/src/main/java/com/hyundai/app/fcm/FcmController.java
+++ b/src/main/java/com/hyundai/app/fcm/FcmController.java
@@ -1,0 +1,39 @@
+package com.hyundai.app.fcm;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * FCM 테스트용 컨트롤러
+ */
+@Api("FCM 테스트용 API")
+@RestController
+@RequestMapping("/api/v1/fcm")
+@RequiredArgsConstructor
+public class FcmController {
+
+    private final FcmPushService fcmPushService;
+
+    /**
+     * @author 황수영
+     * @since 2024/02/20
+     * FCM 푸시 알림 테스트용
+     */
+    @ApiOperation("FCM 테스트용 API")
+    @PostMapping("/test/{deviceToken}")
+    public ResponseEntity<Void> testPush(@PathVariable String deviceToken) throws ExecutionException, InterruptedException {
+        fcmPushService.pushAlarmTest(deviceToken);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}

--- a/src/main/java/com/hyundai/app/fcm/FcmPushService.java
+++ b/src/main/java/com/hyundai/app/fcm/FcmPushService.java
@@ -1,0 +1,49 @@
+package com.hyundai.app.fcm;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+
+import java.util.concurrent.ExecutionException;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * (설명)
+ */
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class FcmPushService {
+    @Autowired
+    private FirebaseApp firebaseApp;
+
+    /**
+     * @author 황수영
+     * @since 2024/02/20
+     * FCM 테스트용 알림
+     */
+    public void pushAlarmTest(String deviceToken) throws ExecutionException, InterruptedException {
+        log.debug("알림 테스트 시작");
+        Notification notification = PushType.createNotification(PushType.WELCOME);
+        Message message = PushType.createMessage(notification, deviceToken);
+        FirebaseMessaging.getInstance(firebaseApp).sendAsync(message).get();
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/20
+     * 랜덤 스팟 FCM 푸시 알림
+     */
+    public void randomSpotPush(String deviceToken) throws ExecutionException, InterruptedException {
+        log.debug("랜덤 스팟 푸시 알림 시작");
+        Notification notification = PushType.createNotification(PushType.RANDOM_SPOT);
+        Message message = PushType.createMessage(notification, deviceToken);
+        FirebaseMessaging.getInstance(firebaseApp).sendAsync(message).get();
+    }
+}

--- a/src/main/java/com/hyundai/app/fcm/PushMessageDto.java
+++ b/src/main/java/com/hyundai/app/fcm/PushMessageDto.java
@@ -1,0 +1,24 @@
+package com.hyundai.app.fcm;
+
+import lombok.Getter;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * 푸시 알림용 DTO
+ */
+
+@Getter
+public class PushMessageDto {
+    private String title;
+    private String content;
+    private String image;
+
+    public static PushMessageDto of(PushType pushType) {
+        PushMessageDto pushMessageDto = new PushMessageDto();
+        pushMessageDto.content = pushType.getContent();
+        pushMessageDto.title = pushType.getTitle();
+        pushMessageDto.image = pushType.getImage();
+        return pushMessageDto;
+    }
+}

--- a/src/main/java/com/hyundai/app/fcm/PushType.java
+++ b/src/main/java/com/hyundai/app/fcm/PushType.java
@@ -1,0 +1,53 @@
+package com.hyundai.app.fcm;
+
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * 푸시 알림 타입 및 메시지 형식 생성 기능
+ */
+@Getter
+@AllArgsConstructor
+public enum PushType {
+    RANDOM_SPOT("흰디의 모험에 온 걸 환영해🎉",
+            "나는 대장 흰디야! 반가워",
+            "https://avatars.githubusercontent.com/u/158237286?s=400&u=db03152b8b64ca04183e918814f02316a5e8c4d9&v=4"),
+    WELCOME("'흰디의 모험' 랜덤 스팟이 열렸어🎁",
+            "랜덤 스팟에서의 이벤트를 확인해봐",
+            "https://avatars.githubusercontent.com/u/158237286?s=400&u=db03152b8b64ca04183e918814f02316a5e8c4d9&v=4");
+
+    private final String title;
+    private final String content;
+    private final String image;
+    
+    /**
+     * @author 황수영
+     * @since 2024/02/20
+     * Notification 생성
+     */
+    public static Notification createNotification(PushType pushType) {
+        PushMessageDto pushMessageDto = PushMessageDto.of(pushType);
+
+        return Notification.builder()
+                .setTitle(pushMessageDto.getTitle())
+                .setBody(pushMessageDto.getContent())
+                .setImage(pushMessageDto.getImage())
+                .build();
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/20
+     * Message 생성 - 이후 필요시 해당 메소드를 통해 유저에게 전달할 데이터 추가 가능
+     */
+    public static Message createMessage(Notification notification, String deviceToken) {
+        return Message.builder()
+                .setToken(deviceToken)
+                .setNotification(notification)
+                .build();
+    }
+}

--- a/src/main/java/com/hyundai/app/member/enumType/Header.java
+++ b/src/main/java/com/hyundai/app/member/enumType/Header.java
@@ -3,7 +3,6 @@ package com.hyundai.app.member.enumType;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-
 /**
  * @author 황수영
  * @since 2024/02/12


### PR DESCRIPTION
## 구현 사항
- FCM 연동 및 푸시 알림 구현
+) 지금 서버에는 변수 설정이 안되서 FCM 알림 관련 api는 로컬에서만 테스트 가능합니다ㅠ

- 환경 변수 설정 필요!!
  - resources/fcm/fcm-key.json에 환경 변수 추가 필요
  - json 파일 참고 : https://sooyoung.atlassian.net/wiki/spaces/TEAM/pages/1900587/FE+BE

![image](https://github.com/hyundai-fruitfruit/frontend/assets/77563814/b41e4276-395f-45a9-83e9-65d711e0d6de)


## 참고 사항

### 랜덤 스팟 로직 순서 참고

모험 시작(GPS 인증) : POST /api/v1/fcm-push/random-spot
-> 30분 뒤 푸시알림옴 
-> 랜덤 스팟 조회 : GET /api/v1/events/random-spot
-> 사용자가 매장 상세보기 클릭할 경우 : /api/v1/stores/{storeId}

![image](https://github.com/hyundai-fruitfruit/frontend/assets/77563814/b6716708-05e9-4a09-aed5-382d2231cfda)

