### PR TITLE
[HEENDY-52-event-create-HOTFIX] 이벤트 등록 시 500 에러 해결

### DIFF
--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -65,7 +65,7 @@
                            , reward_type
                            , reward
                            , content
-                           , <if test="rewardType.toString()=='COUPON'">coupon_id</if>)
+                           <if test="rewardType.toString()=='COUPON'">, coupon_id</if>)
         VALUES  (#{title}
                 , #{startedAt}
                 , #{finishedAt}
@@ -75,7 +75,7 @@
                 , #{rewardType}
                 , #{reward}
                 , #{content}
-                , <if test="rewardType.toString()=='COUPON'">#{couponId}</if>)
+                <if test="rewardType.toString()=='COUPON'">, #{couponId}</if>)
         <selectKey keyProperty="id" resultType="int" order="AFTER">
             SELECT  MAX(id)
             FROM    event


### PR DESCRIPTION
## 구현 사항
- 이벤트 등록 시의 에러 해결

## 참고 사항
- rewardType으로 COUPON 선택 시 coupon_id 필수로 넣어줘야 합니다~!

## 스크린샷
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/1930f5e2-da21-42ae-94eb-e8c362584f50)
