### PR TITLE
[HEENDY-49-event-pagination] 이벤트 페이지네이션 구현

### DIFF
--- a/src/main/java/com/hyundai/app/common/entity/IdWithCriteria.java
+++ b/src/main/java/com/hyundai/app/common/entity/IdWithCriteria.java
@@ -1,0 +1,21 @@
+package com.hyundai.app.common.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/21
+ * 페이징 처리를 위한 id가 포함된 Criteria
+ */
+@Getter
+@AllArgsConstructor
+public class IdWithCriteria {
+    private int storeId;
+    private int pageNum;
+    private int amount;
+
+    public static IdWithCriteria of(int storeId, int pageNum, int amount) {
+        return new IdWithCriteria(storeId, pageNum, amount);
+    }
+}

--- a/src/main/java/com/hyundai/app/common/entity/PageInfo.java
+++ b/src/main/java/com/hyundai/app/common/entity/PageInfo.java
@@ -1,0 +1,55 @@
+package com.hyundai.app.common.entity;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/21
+ * 페이지 정보 계산용 클래스
+ */
+public class PageInfo {
+        private int startPage;
+        private int endPage;
+        private boolean prev, next;
+        private int total;
+        private IdWithCriteria idWithCriteria;
+
+        public PageInfo(IdWithCriteria idWithCriteria, int total) {
+            this.idWithCriteria = idWithCriteria;
+            this.total = total;
+
+            this.endPage = (int) (Math.ceil(idWithCriteria.getPageNum() / 5.0)) * 5;
+            this.startPage = this.endPage - 4;
+
+            int realEnd = (int) (Math.ceil((total * 1.0) / idWithCriteria.getAmount()));
+
+            if (realEnd < this.endPage) {
+                this.endPage = realEnd;
+            }
+
+            this.prev = this.startPage > 1;
+            this.next = this.endPage < realEnd;
+        }
+
+        public int getStartPage() {
+            return startPage;
+        }
+
+        public int getEndPage() {
+            return endPage;
+        }
+
+        public boolean isPrev() {
+            return prev;
+        }
+
+        public boolean isNext() {
+            return next;
+        }
+
+        public int getTotal() {
+            return total;
+        }
+
+        public IdWithCriteria getIdWithCriteria() {
+            return idWithCriteria;
+        }
+}

--- a/src/main/java/com/hyundai/app/event/controller/AdminEventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/AdminEventController.java
@@ -24,10 +24,11 @@ public class AdminEventController {
 
     @GetMapping
     @ApiOperation("어드민용 해당 지점 이벤트 전체 조회 API")
-    public AdventureOfHeendyResponse<EventListResDto> findEventList() {
+    public AdventureOfHeendyResponse<EventListResDto> findEventList(@RequestParam(value = "page", defaultValue = "1") int page,
+                                                                    @RequestParam(value = "size", defaultValue = "10") int size) {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
-        return AdventureOfHeendyResponse.success("지점의 이벤트 목록을 가져왔습니다.", eventService.findEventList(storeId));
+        return AdventureOfHeendyResponse.success("지점의 이벤트 목록을 가져왔습니다.", eventService.findEventList(storeId, page, size));
     }
 
     @PostMapping

--- a/src/main/java/com/hyundai/app/event/dto/EventListResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventListResDto.java
@@ -1,5 +1,7 @@
 package com.hyundai.app.event.dto;
 
+import com.hyundai.app.common.entity.IdWithCriteria;
+import com.hyundai.app.common.entity.PageInfo;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -16,8 +18,10 @@ import java.util.List;
 @AllArgsConstructor
 public class EventListResDto {
     private List<EventDetailResDto> events;
+    private PageInfo pageInfo;
 
-    public static EventListResDto of(List<EventDetailResDto> eventDetailResDtoList) {
-        return new EventListResDto(eventDetailResDtoList);
+    public static EventListResDto from(List<EventDetailResDto> eventDetailResDtoList, IdWithCriteria criteria) {
+        PageInfo pageInfo = new PageInfo(criteria, eventDetailResDtoList.size());
+        return new EventListResDto(eventDetailResDtoList, pageInfo);
     }
 }

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -1,5 +1,6 @@
 package com.hyundai.app.event.mapper;
 
+import com.hyundai.app.common.entity.IdWithCriteria;
 import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventSaveReqDto;
 import com.hyundai.app.event.enumType.EventType;
@@ -16,7 +17,7 @@ import java.util.List;
 public interface EventMapper {
     EventDetailResDto findCurrentEventByEventType(EventType eventType);
 
-    List<EventDetailResDto> findEventList(int storeId);
+    List<EventDetailResDto> findEventList(IdWithCriteria idWithCriteria);
 
     EventDetailResDto findById(int eventId);
 

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -1,9 +1,7 @@
 package com.hyundai.app.event.service;
 
-import com.hyundai.app.event.dto.EventActiveTimeZoneDto;
-import com.hyundai.app.event.dto.EventDetailResDto;
-import com.hyundai.app.event.dto.EventListResDto;
-import com.hyundai.app.event.dto.EventSaveReqDto;
+import com.hyundai.app.common.entity.IdWithCriteria;
+import com.hyundai.app.event.dto.*;
 import com.hyundai.app.event.enumType.EventType;
 import com.hyundai.app.event.mapper.EventActiveTimeMapper;
 import com.hyundai.app.event.mapper.EventMapper;
@@ -39,8 +37,9 @@ public class EventService {
         return eventDetailResDto;
     }
 
-    public EventListResDto findEventList(int storeId) {
-        List<EventDetailResDto> eventDetailResDtoList = eventMapper.findEventList(storeId);
+    public EventListResDto findEventList(int storeId, int page, int size) {
+        IdWithCriteria idWithCriteria = IdWithCriteria.of(storeId, page, size);
+        List<EventDetailResDto> eventDetailResDtoList = eventMapper.findEventList(idWithCriteria);
 
         for (EventDetailResDto eventDetailResDto : eventDetailResDtoList) {
             int eventId = eventDetailResDto.getId();
@@ -48,7 +47,7 @@ public class EventService {
             eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDtoList);
         }
 
-        EventListResDto eventListResDto = EventListResDto.of(eventDetailResDtoList);
+        EventListResDto eventListResDto = EventListResDto.from(eventDetailResDtoList, idWithCriteria);
         return eventListResDto;
     }
 

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -25,18 +25,33 @@
         FETCH   FIRST 1 ROWS ONLY
     </select>
 
-    <select id="findEventList" resultType="eventdetailresdto">
-        SELECT  id
-                , title
-                , event_type
-                , started_at
-                , finished_at
-                , reward_type
-                , max_count
-                , visited_count
-        FROM    event
-        WHERE   store_id = #{storeId}
-        AND     is_deleted = 0
+    <select id="findEventList" parameterType="idwithcriteria" resultType="eventdetailresdto">
+        SELECT  *
+        FROM    (SELECT  ROWNUM AS rnum
+                        , id
+                        , title
+                        , event_type
+                        , started_at
+                        , finished_at
+                        , reward_type
+                        , max_count
+                        , visited_count
+                FROM    (SELECT  id
+                        , title
+                        , event_type
+                        , started_at
+                        , finished_at
+                        , reward_type
+                        , max_count
+                        , visited_count
+                        FROM    event
+                        WHERE   store_id = #{storeId}
+                        AND     is_deleted = 0
+                        ORDER BY id DESC
+                        )
+                WHERE   #{pageNum} * #{amount} >= ROWNUM
+                )
+        WHERE   rnum > (#{pageNum} - 1) * #{amount}
     </select>
 
     <select id="findById" resultType="eventdetailresdto">


### PR DESCRIPTION
## 구현 사항
- 지점용 이벤트 전체 리스트 조회 페이지네이션 구현
- 페이지네이션 구현을 위한 객체 생성 (IdWithCriteria, PageInfo)
- IdWithCriteria는 쿼리문에서 쓰일 page, amount으로 페이지네이션 실행되도록 함
- PageInfo는 Response에 함께 담아 나올 페이지 정보 (프론트에서 버튼 개수 커스텀을 위한 객체)

## 아쉬운 점
- IdWithCriteria, PageInfo의 역할.. 이 애매함

## POSTMAN 스크린샷
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/91072f03-c5ef-4a9a-8b36-5e951900e505) 

## 참고 사항
- 한 페이지 당 10개의 게시글
- 페이지는 5개씩 뜸 (참고 사진은 페이지가 10개씩 뜨는 예시)
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/dc08fba4-878e-4aa2-bf32-77e97bc08c64)
- pageInfo에서 의미를 모르는 부분 있다면 코멘트로 남겨주세요

## 백엔드 참고 문서
- [정적 팩토리 메서드 패턴 (Static Factory Method)](https://inpa.tistory.com/entry/GOF-%F0%9F%92%A0-%EC%A0%95%EC%A0%81-%ED%8C%A9%ED%86%A0%EB%A6%AC-%EB%A9%94%EC%84%9C%EB%93%9C-%EC%83%9D%EC%84%B1%EC%9E%90-%EB%8C%80%EC%8B%A0-%EC%82%AC%EC%9A%A9%ED%95%98%EC%9E%90)