### PR TITLE
[Heendy 50 quartz schedule] Qaurtz로 푸시 알림 예약 발송 기능 구현

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -304,6 +304,26 @@
           <version>RELEASE</version>
           <scope>compile</scope>
       </dependency>
+    <!-- Quartz -->
+    <!-- https://mvnrepository.com/artifact/org.quartz-scheduler/quartz -->
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <!-- https://mvnrepository.com/artifact/org.quartz-scheduler/quartz-jobs -->
+    <dependency>
+      <groupId>org.quartz-scheduler</groupId>
+      <artifactId>quartz-jobs</artifactId>
+      <version>2.3.0</version>
+    </dependency>
+    <!-- spring-context-support - Quartz 지원 스프링 라이브러리 -->
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-context-support</artifactId>
+      <version>${org.springframework-version}</version>
+    </dependency>
+
   </dependencies>
 
   <build>

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring().antMatchers(
                 "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/fcm/**");
+                "/api/v1/auth/**", "/api/v1/fcm-push/**");
     }
 
     @Override

--- a/src/main/java/com/hyundai/app/exception/ErrorCode.java
+++ b/src/main/java/com/hyundai/app/exception/ErrorCode.java
@@ -45,7 +45,10 @@ public enum ErrorCode {
     SERVER_UNAVAILABLE(SERVICE_UNAVAILABLE, "서버에 오류가 발생하였습니다."),
 
     // 400 에러
-    INVALID_PARAMETER(BAD_REQUEST, "입력값이 형식에 맞지 않습니다.");
+    INVALID_PARAMETER(BAD_REQUEST, "입력값이 형식에 맞지 않습니다."),
+
+    // Quartz 관련
+    PUSH_RANDOM_SPOT_UNAVAILABLE(SERVICE_UNAVAILABLE, "랜덤 스팟 푸시 예약 발송 중 오류가 발생하였습니다.");
 
     private final HttpStatus httpStatus;
     private final String message;

--- a/src/main/java/com/hyundai/app/fcm/FcmController.java
+++ b/src/main/java/com/hyundai/app/fcm/FcmController.java
@@ -1,15 +1,15 @@
 package com.hyundai.app.fcm;
 
+import com.hyundai.app.fcm.dto.PushReqDto;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import java.time.LocalDateTime;
 import java.util.concurrent.ExecutionException;
 
 /**
@@ -17,9 +17,10 @@ import java.util.concurrent.ExecutionException;
  * @since 2024/02/20
  * FCM 테스트용 컨트롤러
  */
+@Log4j
 @Api("FCM 테스트용 API")
 @RestController
-@RequestMapping("/api/v1/fcm")
+@RequestMapping("/api/v1/fcm-push")
 @RequiredArgsConstructor
 public class FcmController {
 
@@ -28,12 +29,26 @@ public class FcmController {
     /**
      * @author 황수영
      * @since 2024/02/20
-     * FCM 푸시 알림 테스트용
+     * FCM 푸시 알림 테스트용 - 바로 FCM 알림 발송
      */
     @ApiOperation("FCM 테스트용 API")
     @PostMapping("/test/{deviceToken}")
     public ResponseEntity<Void> testPush(@PathVariable String deviceToken) throws ExecutionException, InterruptedException {
-        fcmPushService.pushAlarmTest(deviceToken);
+        fcmPushService.testPush(deviceToken);
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/02/21
+     * 랜덤 스팟 알림용 : GPS 인증 후 30분 뒤에 푸시 알림
+     */
+    @ApiOperation("랜덤 스팟 알림용 API - GPS 인증 시 해당 api 요청")
+    @PostMapping("/random-spot")
+    public ResponseEntity<Void> pushRandomSpot(@RequestBody PushReqDto pushReqDto) {
+        log.debug("랜덤 스팟 푸시 알림 예약 => device token : " + pushReqDto.getDeviceToken());
+        log.debug("현재 시각 : " + LocalDateTime.now() + " -> " + pushReqDto.getDelayedSeconds() + "초 뒤에 실행");
+        fcmPushService.createRandomSpotPushSchedule(pushReqDto);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/src/main/java/com/hyundai/app/fcm/FcmPushService.java
+++ b/src/main/java/com/hyundai/app/fcm/FcmPushService.java
@@ -2,6 +2,8 @@ package com.hyundai.app.fcm;
 
 import com.google.firebase.FirebaseApp;
 import com.google.firebase.messaging.FirebaseMessaging;
+import com.hyundai.app.fcm.dto.PushReqDto;
+import com.hyundai.app.scheduler.PushScheduler;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +16,7 @@ import java.util.concurrent.ExecutionException;
 /**
  * @author 황수영
  * @since 2024/02/20
- * (설명)
+ * FCM 푸시 알림 관련 서비스단
  */
 @Log4j
 @Service
@@ -22,13 +24,15 @@ import java.util.concurrent.ExecutionException;
 public class FcmPushService {
     @Autowired
     private FirebaseApp firebaseApp;
+    @Autowired
+    private PushScheduler pushScheduler;
 
     /**
      * @author 황수영
      * @since 2024/02/20
      * FCM 테스트용 알림
      */
-    public void pushAlarmTest(String deviceToken) throws ExecutionException, InterruptedException {
+    public void testPush(String deviceToken) throws ExecutionException, InterruptedException {
         log.debug("알림 테스트 시작");
         Notification notification = PushType.createNotification(PushType.WELCOME);
         Message message = PushType.createMessage(notification, deviceToken);
@@ -38,12 +42,10 @@ public class FcmPushService {
     /**
      * @author 황수영
      * @since 2024/02/20
-     * 랜덤 스팟 FCM 푸시 알림
+     * 랜덤 스팟 FCM 푸시 알림 스케쥴러 호출
      */
-    public void randomSpotPush(String deviceToken) throws ExecutionException, InterruptedException {
-        log.debug("랜덤 스팟 푸시 알림 시작");
-        Notification notification = PushType.createNotification(PushType.RANDOM_SPOT);
-        Message message = PushType.createMessage(notification, deviceToken);
-        FirebaseMessaging.getInstance(firebaseApp).sendAsync(message).get();
+    public void createRandomSpotPushSchedule(PushReqDto pushReqDto) {
+        log.debug("createRandomSpotPushSchedule => 랜덤 스팟 푸시 알림");
+        pushScheduler.schedulePushForRandomSpot(pushReqDto);
     }
 }

--- a/src/main/java/com/hyundai/app/fcm/PushType.java
+++ b/src/main/java/com/hyundai/app/fcm/PushType.java
@@ -2,6 +2,7 @@ package com.hyundai.app.fcm;
 
 import com.google.firebase.messaging.Message;
 import com.google.firebase.messaging.Notification;
+import com.hyundai.app.fcm.dto.PushMessageDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 

--- a/src/main/java/com/hyundai/app/fcm/dto/PushMessageDto.java
+++ b/src/main/java/com/hyundai/app/fcm/dto/PushMessageDto.java
@@ -1,5 +1,6 @@
-package com.hyundai.app.fcm;
+package com.hyundai.app.fcm.dto;
 
+import com.hyundai.app.fcm.PushType;
 import lombok.Getter;
 
 /**

--- a/src/main/java/com/hyundai/app/fcm/dto/PushReqDto.java
+++ b/src/main/java/com/hyundai/app/fcm/dto/PushReqDto.java
@@ -1,0 +1,20 @@
+package com.hyundai.app.fcm.dto;
+
+import lombok.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * 유저 디바이스 FCM 푸시 알림용 Request DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PushReqDto {
+    private String deviceToken;
+    private int delayedSeconds;
+
+    public static PushReqDto of(String deviceToken, int time) {
+        return new PushReqDto(deviceToken, time);
+    }
+}

--- a/src/main/java/com/hyundai/app/scheduler/PushScheduler.java
+++ b/src/main/java/com/hyundai/app/scheduler/PushScheduler.java
@@ -1,0 +1,45 @@
+package com.hyundai.app.scheduler;
+
+import com.hyundai.app.exception.AdventureOfHeendyException;
+import com.hyundai.app.fcm.dto.PushReqDto;
+import com.hyundai.app.scheduler.generator.JobDetailGenerator;
+import com.hyundai.app.scheduler.generator.TriggerGenerator;
+import lombok.extern.log4j.Log4j;
+import org.quartz.*;
+import org.springframework.stereotype.Component;
+
+import static com.hyundai.app.exception.ErrorCode.PUSH_RANDOM_SPOT_UNAVAILABLE;
+
+/**
+ * @author 황수영
+ * @since 2024/02/21
+ * 푸시 관련 스케쥴러
+ */
+@Log4j
+@Component
+public class PushScheduler {
+    
+    /**
+     * @author 황수영
+     * @since 2024/02/20
+     * 랜덤 스팟 FCM 푸시 알림 - n분 뒤 발송 예약하는 기능
+     */
+    public void schedulePushForRandomSpot(PushReqDto pushReqDto) {
+        log.debug("PushScheduler : 푸시 알림 발송 시작 " + pushReqDto.getDelayedSeconds() + "초 뒤에 실행");
+        SchedulerFactory schedulerFactory = new org.quartz.impl.StdSchedulerFactory();
+        Scheduler scheduler;
+        try {
+            scheduler = schedulerFactory.getScheduler();
+            scheduler.start();
+
+            JobDetail job = JobDetailGenerator.createPushJobDetail(pushReqDto.getDeviceToken(), pushReqDto.getDelayedSeconds());
+            Trigger trigger = TriggerGenerator.createPushTriggerDelayedBySeconds(pushReqDto.getDelayedSeconds());
+            log.debug("JobDetail : " + job + " Trigger : " + trigger);
+
+            scheduler.scheduleJob(job, trigger);
+        } catch (SchedulerException e) {
+            log.error("PushScheduler : 푸시 알림 에러 발생 " + e);
+            throw new AdventureOfHeendyException(PUSH_RANDOM_SPOT_UNAVAILABLE);
+        }
+    }
+}

--- a/src/main/java/com/hyundai/app/scheduler/SchedulerVariable.java
+++ b/src/main/java/com/hyundai/app/scheduler/SchedulerVariable.java
@@ -1,0 +1,18 @@
+package com.hyundai.app.scheduler;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * @author 황수영
+ * @since 2024/02/22
+ * job에 파라미터로 들어갈 변수값 정의
+ */
+@Getter
+@AllArgsConstructor
+public enum SchedulerVariable {
+    TIME("time"),
+    DEVICE_TOKEN("deviceToken");
+
+    private final String value;
+}

--- a/src/main/java/com/hyundai/app/scheduler/generator/JobDetailGenerator.java
+++ b/src/main/java/com/hyundai/app/scheduler/generator/JobDetailGenerator.java
@@ -1,0 +1,25 @@
+package com.hyundai.app.scheduler.generator;
+
+import com.hyundai.app.scheduler.job.RandomSpotPushJob;
+import org.quartz.JobBuilder;
+import org.quartz.JobDetail;
+
+import static com.hyundai.app.scheduler.SchedulerVariable.DEVICE_TOKEN;
+import static com.hyundai.app.scheduler.SchedulerVariable.TIME;
+
+/**
+ * @author 황수영
+ * @since 2024/02/21
+ * JobDetail 생성
+ */
+public class JobDetailGenerator {
+
+    public static JobDetail createPushJobDetail(String deviceToken, int time) {
+        return JobBuilder.newJob()
+                .ofType(RandomSpotPushJob.class)
+                .withIdentity("RandomSpotPushJob")
+                .usingJobData(DEVICE_TOKEN.getValue(), deviceToken)   // 유저별 디바이스 토큰
+                // .usingJobData(TIME.getValue(), time)                  // 시간
+                .build();
+    }
+}

--- a/src/main/java/com/hyundai/app/scheduler/generator/TriggerGenerator.java
+++ b/src/main/java/com/hyundai/app/scheduler/generator/TriggerGenerator.java
@@ -1,0 +1,24 @@
+package com.hyundai.app.scheduler.generator;
+
+import org.quartz.*;
+
+/**
+ * @author 황수영
+ * @since 2024/02/21
+ * Trigger 생성
+ */
+public class TriggerGenerator {
+
+    public static Trigger createPushTriggerDelayedBySeconds(int delayInSeconds) {
+        return TriggerBuilder.newTrigger()
+                .withIdentity("createPushTriggerDelayedBySeconds")
+                .startAt(DateBuilder.futureDate(delayInSeconds, DateBuilder.IntervalUnit.SECOND))
+                .build();
+    }
+
+    public static Trigger createRandomSpotPushTriggerDelayedByMinutes(int delayInMinutes) {
+        return TriggerBuilder.newTrigger()
+                .startAt(DateBuilder.futureDate(delayInMinutes, DateBuilder.IntervalUnit.MINUTE))
+                .build();
+    }
+}

--- a/src/main/java/com/hyundai/app/scheduler/job/RandomSpotPushJob.java
+++ b/src/main/java/com/hyundai/app/scheduler/job/RandomSpotPushJob.java
@@ -1,0 +1,58 @@
+package com.hyundai.app.scheduler.job;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.Message;
+import com.google.firebase.messaging.Notification;
+import com.hyundai.app.exception.AdventureOfHeendyException;
+import com.hyundai.app.fcm.FcmPushService;
+import com.hyundai.app.fcm.PushType;
+import lombok.extern.log4j.Log4j;
+import org.quartz.*;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.quartz.QuartzJobBean;
+import org.springframework.web.context.support.SpringBeanAutowiringSupport;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.ExecutionException;
+
+import static com.hyundai.app.exception.ErrorCode.PUSH_RANDOM_SPOT_UNAVAILABLE;
+
+/**
+ * @author 황수영
+ * @since 2024/02/20
+ * 랜덤 스팟 예약 푸시 알림용 Job 정의
+ */
+@Log4j
+public class RandomSpotPushJob extends QuartzJobBean {
+    @Autowired
+    private FirebaseApp firebaseApp;
+    @Autowired
+    private FcmPushService fcmPushService;
+
+    @Override
+    protected void executeInternal(JobExecutionContext context) throws JobExecutionException {
+        log.debug("RandomSpotPushAlarmJob 시작! " + LocalDateTime.now());
+        SpringBeanAutowiringSupport.processInjectionBasedOnCurrentContext(this);
+        log.debug("RandomSpotPushAlarmJob 의존성 주입 확인 =>  fcmPushService is null ? " + (fcmPushService == null));
+
+        JobDataMap dataMap = context.getJobDetail().getJobDataMap();
+        log.debug("deviceToken : " + dataMap.getString("deviceToken"));
+
+        createRandomSpotPushNotification(dataMap);
+        log.debug("RandomSpotPushAlarmJob 종료! " + LocalDateTime.now());
+    }
+
+    private void createRandomSpotPushNotification(JobDataMap dataMap) {
+        String deviceToken = dataMap.getString("deviceToken");
+
+        Notification notification = PushType.createNotification(PushType.RANDOM_SPOT);
+        Message message = PushType.createMessage(notification, deviceToken);
+        try {
+            FirebaseMessaging.getInstance(firebaseApp).sendAsync(message).get();
+        } catch (InterruptedException | ExecutionException e) {
+            log.error("createRandomSpotPushNotification 에러 발생!");
+            throw new AdventureOfHeendyException(PUSH_RANDOM_SPOT_UNAVAILABLE);
+        }
+    }
+}


### PR DESCRIPTION
## 구현 사항
- **Qaurtz 설정**
  - https://hackernoon.com/how-to-schedule-jobs-with-quartz-in-spring-boot
  - https://www.baeldung.com/spring-quartz-schedule
- **/api/v1/fcm-push/random-spot => 해당 api 요청 시, 30분 뒤에 랜덤 스팟 푸시 알림 가도록 구현**
  - 유저의 디바이스 토큰, 몇 초 뒤에 알림 요청할 지 req dto에 담아주기
- req dto
  <img width="565" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/0bc792f5-f995-46a1-837d-5cd0f7e47996">
- 푸시 알림 발송 예약 테스트
  <img width="1022" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/3434316f-c16a-4e65-8d38-3d25d4006f85">

## 참고 사항

- 의존성 주입 안되는 이슈
  https://stackoverflow.com/questions/25719179/quartz-does-not-support-autowired