### PR TITLE
feat: 스웨거에 파라미터 제외하는 @ApiIgnore 추가(시큐리티 필터로 파싱되는 memberId)

### DIFF
--- a/src/main/java/com/hyundai/app/friend/controller/FriendController.java
+++ b/src/main/java/com/hyundai/app/friend/controller/FriendController.java
@@ -10,6 +10,7 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import javax.validation.Valid;
 
@@ -28,20 +29,20 @@ public class FriendController {
 
     @GetMapping
     @ApiOperation("전체 친구 리스트 조회 API")
-    public AdventureOfHeendyResponse<FriendListResDto> findFriendList(@MemberId Integer memberId) {
+    public AdventureOfHeendyResponse<FriendListResDto> findFriendList(@ApiIgnore @MemberId Integer memberId) {
         return AdventureOfHeendyResponse.success("친구 목록을 가져왔습니다.", friendService.findFriendList(memberId));
     }
 
     @GetMapping("/{friendId}")
     @ApiOperation("특정 친구 조회 API")
-    public AdventureOfHeendyResponse<FriendDetailResDto> find(@MemberId Integer memberId,
+    public AdventureOfHeendyResponse<FriendDetailResDto> find(@ApiIgnore @MemberId Integer memberId,
                                                               @PathVariable final int friendId) {
         return AdventureOfHeendyResponse.success("친구 흰디에 방문했습니다.", friendService.findFriend(memberId, friendId));
     }
 
     @PostMapping("/{friendId}/mbti")
     @ApiOperation("친구 MBTI 작성 API")
-    public AdventureOfHeendyResponse<String> saveMbti(@MemberId Integer memberId,
+    public AdventureOfHeendyResponse<String> saveMbti(@ApiIgnore @MemberId Integer memberId,
                                                       @PathVariable final int friendId,
                                                       @Valid @RequestBody final MbtiSaveReqDto mbtiSaveReqDto) {
         return AdventureOfHeendyResponse.success("친구 MBTI를 저장했습니다.", friendService.updateMbti(memberId, friendId, mbtiSaveReqDto));

--- a/src/main/java/com/hyundai/app/member/controller/MemberController.java
+++ b/src/main/java/com/hyundai/app/member/controller/MemberController.java
@@ -5,12 +5,14 @@ import com.hyundai.app.member.service.MemberService;
 import com.hyundai.app.security.methodparam.MemberId;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiParam;
 import lombok.extern.log4j.Log4j;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * @author 황수영
@@ -29,7 +31,7 @@ public class MemberController {
 
     @GetMapping
     @ApiOperation("회원 정보 조회 API")
-    public ResponseEntity<MemberResDto> login(@MemberId Integer memberId) {
+    public ResponseEntity<MemberResDto> login(@ApiIgnore @MemberId Integer memberId) {
         log.debug("회원 정보 조회 : " + memberId);
         MemberResDto memberResDto = memberService.getMemberInfo(memberId);
         return new ResponseEntity<>(memberResDto, HttpStatus.ACCEPTED);

--- a/src/main/java/com/hyundai/app/store/controller/StoreController.java
+++ b/src/main/java/com/hyundai/app/store/controller/StoreController.java
@@ -11,6 +11,7 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 /**
  * @author 황수영
@@ -49,7 +50,7 @@ public class StoreController {
     public ResponseEntity<Void> createReview(
             @PathVariable int storeId,
             @RequestBody ReviewReqDto reviewReqDto,
-            @MemberId int memberId
+            @ApiIgnore @MemberId int memberId
     ) {
         storeService.createReview(storeId, memberId, reviewReqDto);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);


### PR DESCRIPTION
## 구현 사항

- **스웨거에 필요없는 파라미터는 @ApiIgnore 추가 필요!**
- **시큐리티 필터 거쳐서 JWT 토큰 -> memberId로 파싱한 값인 @MemberId 제외하도록 @ApiIgnore 추가**

## 참고 사항

