### PR TITLE
[HEENDY-43-user-visit-QR] 유저용 이벤트 참여 API 구현

### DIFF
--- a/src/main/java/com/hyundai/app/coupon/controller/CouponController.java
+++ b/src/main/java/com/hyundai/app/coupon/controller/CouponController.java
@@ -1,0 +1,34 @@
+package com.hyundai.app.coupon.controller;
+
+import com.hyundai.app.common.AdventureOfHeendyResponse;
+import com.hyundai.app.coupon.domain.Coupon;
+import com.hyundai.app.coupon.service.CouponService;
+import com.hyundai.app.security.methodparam.MemberId;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.annotations.ApiIgnore;
+
+import java.util.List;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/23
+ * 사용자용 쿠폰 컨트롤러
+ */
+@Api("사용자용 쿠폰 관련 API")
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/coupons")
+@RestController
+public class CouponController {
+    private final CouponService couponService;
+
+    @ApiOperation("사용자용 쿠폰 전체 조회 API")
+    @GetMapping
+    public AdventureOfHeendyResponse<List<Coupon>> findCouponList(@ApiIgnore @MemberId Integer memberId) {
+        return AdventureOfHeendyResponse.success("사용자의 쿠폰 목록을 가져왔습니다.", couponService.findMemberCouponList(memberId));
+    }
+}

--- a/src/main/java/com/hyundai/app/coupon/domain/MemberCoupon.java
+++ b/src/main/java/com/hyundai/app/coupon/domain/MemberCoupon.java
@@ -1,0 +1,29 @@
+package com.hyundai.app.coupon.domain;
+
+import com.hyundai.app.common.entity.BaseEntity;
+
+import java.time.LocalDate;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/22
+ * 유저가 가지고 있는 쿠폰 엔티티
+ */
+public class MemberCoupon extends BaseEntity {
+    private int id;
+    private int memberId;
+    private int couponId;
+    private int isUsed;
+    private String channelType;
+    private LocalDate expiredAt;
+
+    public MemberCoupon(int memberId, int couponId, String channelType) {
+        this.memberId = memberId;
+        this.couponId = couponId;
+        this.channelType = channelType;
+    }
+
+    public static MemberCoupon of(int memberId, int couponId, String channelType) {
+        return new MemberCoupon(memberId, couponId, channelType);
+    }
+}

--- a/src/main/java/com/hyundai/app/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/hyundai/app/coupon/mapper/CouponMapper.java
@@ -13,4 +13,6 @@ import java.util.List;
 @Mapper
 public interface CouponMapper {
     List<Coupon> findCouponList(int storeId);
+
+    Coupon findById(int couponId);
 }

--- a/src/main/java/com/hyundai/app/coupon/mapper/CouponMapper.java
+++ b/src/main/java/com/hyundai/app/coupon/mapper/CouponMapper.java
@@ -15,4 +15,6 @@ public interface CouponMapper {
     List<Coupon> findCouponList(int storeId);
 
     Coupon findById(int couponId);
+
+    List<Coupon> findMemberCouponList(Integer memberId);
 }

--- a/src/main/java/com/hyundai/app/coupon/mapper/MemberCouponMapper.java
+++ b/src/main/java/com/hyundai/app/coupon/mapper/MemberCouponMapper.java
@@ -1,0 +1,12 @@
+package com.hyundai.app.coupon.mapper;
+
+import com.hyundai.app.coupon.domain.MemberCoupon;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/22
+ * 쿠폰을 가진 사용자 매퍼
+ */
+public interface MemberCouponMapper {
+    void saveMemberCoupon(MemberCoupon memberCoupon);
+}

--- a/src/main/java/com/hyundai/app/coupon/service/CouponService.java
+++ b/src/main/java/com/hyundai/app/coupon/service/CouponService.java
@@ -27,4 +27,14 @@ public class CouponService {
         }
         return couponList;
     }
+
+    public List<Coupon> findMemberCouponList(Integer memberId) {
+        List<Coupon> couponList = couponMapper.findMemberCouponList(memberId);
+        for (Coupon coupon: couponList) {
+            CouponType couponType = coupon.getCouponType();
+            String description = couponType.getDescription(coupon);
+            coupon.updateContent(description);
+        }
+        return couponList;
+    }
 }

--- a/src/main/java/com/hyundai/app/event/controller/EventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventController.java
@@ -2,17 +2,17 @@ package com.hyundai.app.event.controller;
 
 import com.hyundai.app.common.AdventureOfHeendyResponse;
 import com.hyundai.app.event.dto.EventDetailResDto;
+import com.hyundai.app.event.dto.EventParticipateResDto;
 import com.hyundai.app.event.enumType.EventType;
 import com.hyundai.app.event.service.EventService;
+import com.hyundai.app.security.methodparam.MemberId;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import springfox.documentation.annotations.ApiIgnore;
 
 import java.util.Random;
 
@@ -33,6 +33,13 @@ public class EventController {
     @ApiOperation("유저용 현재 열린 이벤트 조회 API")
     public AdventureOfHeendyResponse<EventDetailResDto> findCurrentEventByEventType(@RequestParam EventType eventType) {
         return AdventureOfHeendyResponse.success("이벤트 목록을 가져왔습니다.", eventService.findCurrentEventByEventType(eventType));
+    }
+
+    @PostMapping("{eventId}/participate")
+    @ApiOperation("유저용 이벤트 참여 API")
+    public AdventureOfHeendyResponse<EventParticipateResDto> participateEvent(@ApiIgnore @MemberId Integer memberId,
+                                                                              @PathVariable int eventId){
+        return AdventureOfHeendyResponse.success("이벤트 참여에 성공했습니다.", eventService.participateEvent(memberId, eventId));
     }
 
     /**

--- a/src/main/java/com/hyundai/app/event/domain/MemberEvent.java
+++ b/src/main/java/com/hyundai/app/event/domain/MemberEvent.java
@@ -11,4 +11,13 @@ public class MemberEvent extends BaseEntity {
     private int id;
     private int eventId;
     private int memberId;
+
+    public MemberEvent(int eventId, int memberId) {
+        this.eventId = eventId;
+        this.memberId = memberId;
+    }
+
+    public static MemberEvent of(int eventId, int memberId) {
+        return new MemberEvent(eventId, memberId);
+    }
 }

--- a/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
@@ -32,6 +32,7 @@ public class EventDetailResDto {
     private LocalDate finishedAt;
     private int maxCount;
     private int visitedCount;
+    private int couponId;
     private List<EventActiveTimeZoneDto> eventActiveTimeZoneDto;
 
     public void setActiveTimeList(List<EventActiveTimeZoneDto> eventActiveTimeZoneDto) {

--- a/src/main/java/com/hyundai/app/event/dto/EventParticipateResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventParticipateResDto.java
@@ -1,0 +1,32 @@
+package com.hyundai.app.event.dto;
+
+import com.hyundai.app.coupon.domain.Coupon;
+import lombok.Getter;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/22
+ * 이벤트 참여 응답 DTO
+ */
+@Getter
+public class EventParticipateResDto {
+    EventDetailResDto eventDetailResDto;
+    Coupon coupon;
+
+    public EventParticipateResDto(EventDetailResDto eventDetailResDto, Coupon coupon) {
+        this.eventDetailResDto = eventDetailResDto;
+        this.coupon = coupon;
+    }
+
+    public static EventParticipateResDto from(EventDetailResDto eventDetailResDto, Coupon coupon) {
+        return new EventParticipateResDto(eventDetailResDto, coupon);
+    }
+
+    public static EventParticipateResDto of(EventDetailResDto eventDetailResDto) {
+        return new EventParticipateResDto(eventDetailResDto, null);
+    }
+
+    public void updateCoupon(Coupon coupon) {
+        this.coupon = coupon;
+    }
+}

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -28,4 +28,6 @@ public interface EventMapper {
     void delete(int eventId);
 
     List<EventDetailResDto> findEventAllByEventType(EventType eventType);
+
+    void increaseVisitedCount(int eventId);
 }

--- a/src/main/java/com/hyundai/app/event/mapper/MemberEventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/MemberEventMapper.java
@@ -1,0 +1,14 @@
+package com.hyundai.app.event.mapper;
+
+import com.hyundai.app.event.domain.MemberEvent;
+import org.apache.ibatis.annotations.Mapper;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/21
+ * 이벤트에 참여한 회원 Mapper
+ */
+@Mapper
+public interface MemberEventMapper {
+    void saveMemberEvent(MemberEvent memberEvent);
+}

--- a/src/main/resources/mapper/CouponMapper.xml
+++ b/src/main/resources/mapper/CouponMapper.xml
@@ -17,4 +17,16 @@
         FROM    coupon
         WHERE   store_id = #{storeId}
     </select>
+
+    <select id="findById" parameterType="int" resultType="coupon">
+        SELECT  id
+             , coupon_type
+             , discount_rate
+             , discount_amount
+             , minimum_amount
+             , started_at
+             , finished_at
+        FROM    coupon
+        WHERE   id = #{couponId}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/CouponMapper.xml
+++ b/src/main/resources/mapper/CouponMapper.xml
@@ -29,4 +29,18 @@
         FROM    coupon
         WHERE   id = #{couponId}
     </select>
+
+    <select id="findMemberCouponList" parameterType="int" resultType="coupon">
+        SELECT  id
+                , coupon_type
+                , discount_rate
+                , discount_amount
+                , minimum_amount
+                , started_at
+                , finished_at
+        FROM    coupon
+        WHERE   id IN (SELECT    coupon_id
+                      FROM      member_coupon
+                      WHERE     member_id = #{memberId})
+    </select>
 </mapper>

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -66,6 +66,7 @@
                 , finished_at
                 , max_count
                 , visited_count
+                , coupon_id
         FROM    event
         WHERE   id = #{eventId}
     </select>
@@ -139,4 +140,10 @@
         AND     max_count >= visited_count
         AND     is_deleted = 0
     </select>
+
+    <update id="increaseVisitedCount" parameterType="int">
+        UPDATE  event
+        SET     visited_count = visited_count + 1
+        WHERE   id = #{eventId}
+    </update>
 </mapper>

--- a/src/main/resources/mapper/MemberCouponMapper.xml
+++ b/src/main/resources/mapper/MemberCouponMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hyundai.app.coupon.mapper.MemberCouponMapper">
+    <!--    @author 엄상은  -->
+    <!--    @since 2024/02/22  -->
+    <!--    쿠폰을 가진 멤버 mapper  -->
+    <insert id="saveMemberCoupon" parameterType="membercoupon">
+        INSERT  INTO member_coupon (member_id
+                                   , coupon_id
+                                   , channel_type)
+        VALUES  (#{memberId}
+                , #{couponId}
+                , #{channelType})
+    </insert>
+</mapper>

--- a/src/main/resources/mapper/MemberEventMapper.xml
+++ b/src/main/resources/mapper/MemberEventMapper.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.hyundai.app.event.mapper.MemberEventMapper">
+    <!--    @author 엄상은  -->
+    <!--    @since 2024/02/22  -->
+    <!--    이벤트에 참여한 멤버 mapper  -->
+    <insert id="saveMemberEvent" parameterType="memberevent">
+        INSERT  INTO member_event (member_id
+                                  , event_id)
+        VALUES  (#{memberId}
+                , #{eventId})
+    </insert>
+</mapper>


### PR DESCRIPTION
## 구현 사항
- 유저용 이벤트 참여 API (POST /api/v1/events/{eventId}/participate)
- 유저용 쿠폰 목록 조회 API (GET /api/v1/coupons)

## 관련 이슈
- [JIRA 43번 이슈](https://sooyoung.atlassian.net/browse/HEENDY-43?atlOrigin=eyJpIjoiODM3NjRjY2UzMTQ4NDYxZjkyZjBlMzE3MDJjZDA5NzUiLCJwIjoiaiJ9)

## 이벤트 QR 플로우
- 관리자는 이벤트 내용을 QR로 설치한다
- 사용자는 매장 내에 비치된 QR코드를 앱 내의 카메라로 인식한다
- QR 인식 시의 API 요청 경로: POST /api/v1/events/{eventId}/participate

## POSTMAN 스크린샷
### 유저용 이벤트 참여 API
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/7b9722e7-f0da-4efe-918f-ec4f6f7d69aa)

### 유저용 쿠폰 목록 조회 API
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/9b9f529e-cc79-4e5d-a355-230bfa72fff8)

## 참고 사항
현재 사용자가 쿠폰을 얻었을 때 유효기간이 설정되어 있지 않음
특정 기간만큼의 유효기간을 가지는 정책을 만들거나, 쿠폰의 유효일을 따오거나, 당일만 유효한 쿠폰으로 구성
(회의 필요)
