### PR TITLE
[Heendy 62 chatbot guide] 챗봇 가이드 기능 구현

### DIFF
--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring().antMatchers(
                 "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/fcm-push/**");
+                "/api/v1/auth/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**");
     }
 
     @Override

--- a/src/main/java/com/hyundai/app/exception/ErrorCode.java
+++ b/src/main/java/com/hyundai/app/exception/ErrorCode.java
@@ -35,11 +35,14 @@ public enum ErrorCode {
     STORE_ID_INVALID(BAD_REQUEST, "해당하는 매장 id가 없습니다."),
     HASHTAG_ID_INVALID(BAD_REQUEST, "해당하는 해시태그 id가 없습니다."),
     MEMBER_ID_INVALID(BAD_REQUEST, "해당하는 회원 id가 없습니다."),
+    MEMBER_NOT_EXIST(BAD_REQUEST, "해당하는 회원 oauth id가 존재하지 않습니다."),
 
     // 이벤트
     EVENT_NOT_EXIST(BAD_REQUEST, "해당하는 이벤트가 존재하지 않습니다."),
     EVENT_TYPE_NOT_EXIST(BAD_REQUEST, "이벤트 타입은 RESTAURANT, CAFE, SHOPPING, RANDOM 중 하나이어야 합니다."),
 
+    // 매장
+    STORE_NOT_EXIST(BAD_REQUEST, "해당하는 매장 id가 존재하지 않습니다."),
 
     // 500 에러
     SERVER_UNAVAILABLE(SERVICE_UNAVAILABLE, "서버에 오류가 발생하였습니다."),

--- a/src/main/java/com/hyundai/app/guide/GuideController.java
+++ b/src/main/java/com/hyundai/app/guide/GuideController.java
@@ -1,0 +1,56 @@
+package com.hyundai.app.guide;
+
+import com.hyundai.app.guide.dto.GuideTypeResDto;
+import com.hyundai.app.guide.dto.HashtagListResDto;
+import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.service.HashtagService;
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/26
+ * (설명)
+ */
+@Log4j
+@Api("대장 흰디 가이드용 API")
+@RestController
+@RequestMapping("/api/v1/heendy-guide")
+public class GuideController {
+
+    @Autowired
+    @Qualifier("hashtagServiceImpl")
+    private HashtagService hashtagService;
+
+    @GetMapping
+    @ApiOperation("전체 가이드 조회")
+    public ResponseEntity<List<GuideTypeResDto>> getGuideAll() {
+        List<GuideTypeResDto> guideTypeList = GuideType.getGuideResDtoAll();
+        log.debug("전체 가이드 조회 : " + guideTypeList);
+        return new ResponseEntity<>(guideTypeList, HttpStatus.ACCEPTED);
+    }
+
+    @GetMapping("/{guideType}")
+    @ApiOperation("분류별 해시태그 조회 - 해당 분류의 모든 해시태그 조회하기 - 식당/쇼핑 매장")
+    public ResponseEntity<List<HashtagListResDto>> getGuideByCategory(@PathVariable("guideType") String guideType) {
+        log.debug("분류별 해시태그 조회 =>  guideType : " + guideType);
+        List<HashtagListResDto> hashtagListResDto = hashtagService.getHashtagAllByGuideType(guideType);
+        return new ResponseEntity<>(hashtagListResDto, HttpStatus.ACCEPTED);
+    }
+
+    @GetMapping("/hashtag")
+    @ApiOperation("해시 태그 선택 시, 관련 식당들 조회")
+    public ResponseEntity<List<Store>> findStoresByHashtags(@RequestParam("hashtagId")int hashtagId) {
+        log.debug("해시 태그 선택 시, 관련 식당들 조회 => 해시 태그 : " + hashtagId);
+        List<Store> stores = hashtagService.findStoresByMostSavedHashtags(hashtagId);
+        return new ResponseEntity<>(stores, HttpStatus.ACCEPTED);
+    }
+}

--- a/src/main/java/com/hyundai/app/guide/GuideController.java
+++ b/src/main/java/com/hyundai/app/guide/GuideController.java
@@ -2,7 +2,7 @@ package com.hyundai.app.guide;
 
 import com.hyundai.app.guide.dto.GuideTypeResDto;
 import com.hyundai.app.guide.dto.HashtagListResDto;
-import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.dto.StoreResDto;
 import com.hyundai.app.store.service.HashtagService;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
@@ -48,9 +48,9 @@ public class GuideController {
 
     @GetMapping("/hashtag")
     @ApiOperation("해시 태그 선택 시, 관련 식당들 조회")
-    public ResponseEntity<List<Store>> findStoresByHashtags(@RequestParam("hashtagId")int hashtagId) {
+    public ResponseEntity<List<StoreResDto>> findStoresByHashtags(@RequestParam("hashtagId")int hashtagId) {
         log.debug("해시 태그 선택 시, 관련 식당들 조회 => 해시 태그 : " + hashtagId);
-        List<Store> stores = hashtagService.findStoresByMostSavedHashtags(hashtagId);
+        List<StoreResDto> stores = hashtagService.findStoresByMostSavedHashtags(hashtagId);
         return new ResponseEntity<>(stores, HttpStatus.ACCEPTED);
     }
 }

--- a/src/main/java/com/hyundai/app/guide/GuideType.java
+++ b/src/main/java/com/hyundai/app/guide/GuideType.java
@@ -1,0 +1,34 @@
+package com.hyundai.app.guide;
+
+import com.hyundai.app.guide.dto.GuideTypeResDto;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * @author 황수영
+ * @since 2024/02/26
+ * 챗봇 가이드 타입 정의
+ */
+@Getter
+@AllArgsConstructor
+public enum GuideType {
+
+    FLOOR(1000, "층별 설명을 듣고 싶어", List.of()),
+    RANDOM_SPOT(1001, "랜덤 스팟이 뭐야?" , List.of()),
+    RESTAURANT(1002, "식당 추천 해줘" , List.of("FOOD", "ATMOSPHERE", "ETC")),
+    SHOPPING(1003, "쇼핑 추천 해줘", List.of("STYLE", "PRICE", "ETC"));
+
+    private final int id;
+    private final String korean;
+    private final List<String> category;
+
+    public static List<GuideTypeResDto> getGuideResDtoAll() {
+        return Arrays.stream(GuideType.values())
+                .map(g -> new GuideTypeResDto(g, g.korean, g.category))
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/hyundai/app/guide/dto/GuideTypeResDto.java
+++ b/src/main/java/com/hyundai/app/guide/dto/GuideTypeResDto.java
@@ -1,0 +1,20 @@
+package com.hyundai.app.guide.dto;
+
+import com.hyundai.app.guide.GuideType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/26
+ * 챗봇 가이드 타입 Res DTO
+ */
+@Getter
+@AllArgsConstructor
+public class GuideTypeResDto {
+    private GuideType guideType;
+    private String korean;
+    private final List<String> category;
+}

--- a/src/main/java/com/hyundai/app/guide/dto/HashtagListResDto.java
+++ b/src/main/java/com/hyundai/app/guide/dto/HashtagListResDto.java
@@ -1,0 +1,20 @@
+package com.hyundai.app.guide.dto;
+
+import com.hyundai.app.store.domain.Hashtag;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/26
+ * 해시태그 리스트 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class HashtagListResDto {
+
+    private String title;
+    private List<Hashtag> hashtags;
+}

--- a/src/main/java/com/hyundai/app/member/dto/LoginReqDto.java
+++ b/src/main/java/com/hyundai/app/member/dto/LoginReqDto.java
@@ -11,6 +11,6 @@ import lombok.Setter;
 @Getter
 @Setter
 public class LoginReqDto {
-    private String oauthType;
-    private String loginToken;
+    private String oauthType; // KAKAO
+    private String loginToken; // OAuth의 acceess token
 }

--- a/src/main/java/com/hyundai/app/store/mapper/HashtagMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/HashtagMapper.java
@@ -4,6 +4,8 @@ import com.hyundai.app.store.domain.Hashtag;
 import com.hyundai.app.store.domain.StoreHashtag;
 import org.apache.ibatis.annotations.Param;
 
+import java.util.List;
+
 /**
  * @author 황수영
  * @since 2024/02/17
@@ -15,4 +17,5 @@ public interface HashtagMapper {
     void createStoreHashtag(@Param("storeId") int storeId, @Param("hashtagId") int hashtagId);
     StoreHashtag getStoreHashtag(@Param("storeId") int storeId, @Param("hashtagId") int hashtagId);
     void updateStoreHashtag(@Param("storeId") int storeId, @Param("hashtagId") int hashtagId);
+    List<Hashtag> getHashtagByCategory(@Param("category") String category);
 }

--- a/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
@@ -19,4 +19,5 @@ public interface StoreMapper {
     void updateAvgScore(@Param("storeId") int storeId, @Param("avgScore") double avgScore);
     void updateReviewCount(@Param("storeId") int storeId);
     List<Review> getReviews(@Param("storeId") int storeId);
+    List<Store> getStoresByHashtagId(@Param("hashtagId") int hashtagId);
 }

--- a/src/main/java/com/hyundai/app/store/service/HashtagService.java
+++ b/src/main/java/com/hyundai/app/store/service/HashtagService.java
@@ -1,0 +1,16 @@
+package com.hyundai.app.store.service;
+
+import com.hyundai.app.guide.dto.HashtagListResDto;
+import com.hyundai.app.store.domain.Store;
+
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/26
+ * 매장/리뷰 해시태그 관련 서비스단
+ */
+public interface HashtagService {
+    List<HashtagListResDto> getHashtagAllByGuideType(String guideType);
+    List<Store> findStoresByMostSavedHashtags(int hashtagId);
+}

--- a/src/main/java/com/hyundai/app/store/service/HashtagService.java
+++ b/src/main/java/com/hyundai/app/store/service/HashtagService.java
@@ -1,7 +1,7 @@
 package com.hyundai.app.store.service;
 
 import com.hyundai.app.guide.dto.HashtagListResDto;
-import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.dto.StoreResDto;
 
 import java.util.List;
 
@@ -12,5 +12,5 @@ import java.util.List;
  */
 public interface HashtagService {
     List<HashtagListResDto> getHashtagAllByGuideType(String guideType);
-    List<Store> findStoresByMostSavedHashtags(int hashtagId);
+    List<StoreResDto> findStoresByMostSavedHashtags(int hashtagId);
 }

--- a/src/main/java/com/hyundai/app/store/service/HashtagServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/HashtagServiceImpl.java
@@ -4,6 +4,7 @@ import com.hyundai.app.guide.GuideType;
 import com.hyundai.app.guide.dto.HashtagListResDto;
 import com.hyundai.app.store.domain.Hashtag;
 import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.dto.StoreResDto;
 import com.hyundai.app.store.mapper.HashtagMapper;
 import com.hyundai.app.store.mapper.StoreMapper;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +13,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * @author 황수영
@@ -35,20 +37,18 @@ public class HashtagServiceImpl implements HashtagService{
     @Override
     public List<HashtagListResDto> getHashtagAllByGuideType(String guideType) {
         log.debug("분류별 해시태그 조회 분류 : " + guideType);
-        GuideType guideTypeEnum = GuideType.valueOf(guideType.toUpperCase()); // 식당 분류
+        GuideType guideTypeEnum = GuideType.valueOf(guideType.toUpperCase());
         log.debug("분류별 해시태그 조회 분류 : " + guideTypeEnum);
 
         // TODO: 캐싱 필요!
-        List<HashtagListResDto> result = new ArrayList<>(); // 식당의 모든 해시태그들 조회
+        List<HashtagListResDto> result = new ArrayList<>();
 
         for (String category : guideTypeEnum.getCategory()) {
-            log.debug("분류별 해시태그 조회 => category : " + category);
             List<Hashtag> hashtags = hashtagMapper.getHashtagByCategory(category);
             HashtagListResDto hashtagListResDto = new HashtagListResDto(category, hashtags);
             result.add(hashtagListResDto);
-            log.debug("분류별 해시태그 조회" + hashtagListResDto);
+            log.debug("분류별 해시태그 조회 => category : " + category + " : " + hashtagListResDto);
         }
-        // 정렬된 순서대로 조회
         return result;
     }
 
@@ -59,9 +59,10 @@ public class HashtagServiceImpl implements HashtagService{
      * 해당 해시태그가 가장 많이 저장된 매장들 조회
      */
     @Override
-    public List<Store> findStoresByMostSavedHashtags(int hashtagId) {
+    public List<StoreResDto> findStoresByMostSavedHashtags(int hashtagId) {
+        // TODO: 캐싱 필요!
         List<Store> stores = storeMapper.getStoresByHashtagId(hashtagId);
-        // 정렬된 순서대로 조회
-        return stores;
+        return stores.stream().map(StoreResDto::of)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/hyundai/app/store/service/HashtagServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/HashtagServiceImpl.java
@@ -1,0 +1,67 @@
+package com.hyundai.app.store.service;
+
+import com.hyundai.app.guide.GuideType;
+import com.hyundai.app.guide.dto.HashtagListResDto;
+import com.hyundai.app.store.domain.Hashtag;
+import com.hyundai.app.store.domain.Store;
+import com.hyundai.app.store.mapper.HashtagMapper;
+import com.hyundai.app.store.mapper.StoreMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @author 황수영
+ * @since 2024/02/26
+ * (설명)
+ */
+@Log4j
+@Service
+@RequiredArgsConstructor
+public class HashtagServiceImpl implements HashtagService{
+
+    private final StoreMapper storeMapper;
+    private final HashtagMapper hashtagMapper;
+
+
+    /**
+     * @author 황수영
+     * @since 2024/02/26
+     * 분류별 해시태그 전체 조회
+     */
+    @Override
+    public List<HashtagListResDto> getHashtagAllByGuideType(String guideType) {
+        log.debug("분류별 해시태그 조회 분류 : " + guideType);
+        GuideType guideTypeEnum = GuideType.valueOf(guideType.toUpperCase()); // 식당 분류
+        log.debug("분류별 해시태그 조회 분류 : " + guideTypeEnum);
+
+        // TODO: 캐싱 필요!
+        List<HashtagListResDto> result = new ArrayList<>(); // 식당의 모든 해시태그들 조회
+
+        for (String category : guideTypeEnum.getCategory()) {
+            log.debug("분류별 해시태그 조회 => category : " + category);
+            List<Hashtag> hashtags = hashtagMapper.getHashtagByCategory(category);
+            HashtagListResDto hashtagListResDto = new HashtagListResDto(category, hashtags);
+            result.add(hashtagListResDto);
+            log.debug("분류별 해시태그 조회" + hashtagListResDto);
+        }
+        // 정렬된 순서대로 조회
+        return result;
+    }
+
+
+    /**
+     * @author 황수영
+     * @since 2024/02/14
+     * 해당 해시태그가 가장 많이 저장된 매장들 조회
+     */
+    @Override
+    public List<Store> findStoresByMostSavedHashtags(int hashtagId) {
+        List<Store> stores = storeMapper.getStoresByHashtagId(hashtagId);
+        // 정렬된 순서대로 조회
+        return stores;
+    }
+}

--- a/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreServiceImpl.java
@@ -42,7 +42,10 @@ public class StoreServiceImpl implements StoreService {
     @Override
     public StoreResDto getStoreDetail(int storeId) {
         Store store = storeMapper.getStoreDetail(storeId);
-        log.debug("매장 번호 :" + storeId + " 정보 조회 : " + store.toString());
+        if (store == null) {
+            throw new AdventureOfHeendyException(STORE_NOT_EXIST);
+        }
+        log.debug("매장 번호 :" + storeId + " 정보 조회 : " + store);
         List<Hashtag> popularHashtags = storeMapper.getPopularHashtagsOfStore(storeId);
         log.debug("가장 많이 선택된 해시태그들 5개 조회 : " + popularHashtags.toString());
 
@@ -149,6 +152,4 @@ public class StoreServiceImpl implements StoreService {
             throw new AdventureOfHeendyException(HASHTAG_ID_INVALID);
         }
     }
-
-
 }

--- a/src/main/resources/mapper/HashtagMapper.xml
+++ b/src/main/resources/mapper/HashtagMapper.xml
@@ -49,4 +49,10 @@
         AND store_id = #{storeId}
     </update>
 
+    <select id="getHashtagByCategory" >
+        SELECT id AS id
+            , name AS name
+        FROM hashtag
+        WHERE category = #{category}
+    </select>
 </mapper>

--- a/src/main/resources/mapper/StoreMapper.xml
+++ b/src/main/resources/mapper/StoreMapper.xml
@@ -22,14 +22,14 @@
     </select>
 
     <select id="getReviews" resultType="com.hyundai.app.store.domain.Review" >
-        SELECT id
-        , member_id
-        , store_id
-        , is_deleted
-        , created_at
-        , updated_at
-        , score
-        , content
+        SELECT  id
+                , member_id
+                , store_id
+                , is_deleted
+                , created_at
+                , updated_at
+                , score
+                , content
         FROM review
         WHERE store_id = #{storeId}
     </select>
@@ -74,4 +74,22 @@
         SET review_count = review_count + 1
         WHERE id = #{storeId}
     </update>
+
+    <select id="getStoresByHashtagId">
+        SELECT  store.id AS id
+                , store.name AS name
+                , store.contact_number AS contactNumber
+                , store.main_category AS mainCategory
+                , store.sub_category AS subCategory
+                , store.floor AS floor
+                , store.description AS description
+                , store.avg_score AS avgScore
+                , store.review_count AS reviewCount
+        FROM store
+        INNER JOIN store_hashtag
+        ON store.id = store_hashtag.store_id
+        WHERE store_hashtag.hashtag_id = #{hashtagId}
+        ORDER BY store_hashtag.count DESC
+        FETCH FIRST 5 ROWS ONLY
+    </select>
 </mapper>


### PR DESCRIPTION
## 구현 사항
- /api/v1/heendy-guide
  - 전체 가이드 조회
- /api/v1/heendy-guide/{guideType}
  - 해당 가이드 타입의 전체 해시태그 조회
- /api/v1/heendy-guide/hashtag?hashtagId=101
  - 해시 태그별 매장 추천 조회

<img width="268" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/4d9059a8-678b-4d32-a750-752d49148e86">



## 참고 사항

- 해시태그 id 고정
<img width="676" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/62d4b119-f7c1-4b5d-b932-86e793c2510b">