### PR TITLE
[HEENDY-‪46-socket] 이벤트 참여 API 및 소켓 연결 설정

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,16 @@
       <artifactId>javase</artifactId>
       <version>3.5.0</version>
     </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-websocket</artifactId>
+      <version>${org.springframework-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-messaging</artifactId>
+      <version>${org.springframework-version}</version>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring().antMatchers(
                 "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket", "/websocket/**");
+                "/api/v1/auth/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket-demo", "/websocket-demo/**");
     }
 
     @Override

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring().antMatchers(
                 "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket-demo", "/websocket-demo/**");
+                "/api/v1/auth/**", "/api/v1/admin/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket-demo", "/websocket-demo/**");
     }
 
     @Override
@@ -61,6 +61,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                 .and()
                     .authorizeRequests()
                     .antMatchers("/api/v1/auth/**").permitAll()
+                    .antMatchers("/api/v1/admin/**").permitAll()
                     .antMatchers("/api/v1/fcm/**").permitAll()
                     .antMatchers("/api/v1/stores/**").authenticated()
                     .antMatchers("/api/v1/members/**").authenticated()

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring().antMatchers(
                 "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**");
+                "/api/v1/auth/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket", "/websocket/**");
     }
 
     @Override

--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -38,7 +38,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
         web.ignoring().antMatchers(
                 "/", "/resources/**",
                 "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/admin/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket-demo", "/websocket-demo/**");
+                "/api/v1/auth/**", "/api/v1/admin/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket/**");
     }
 
     @Override

--- a/src/main/java/com/hyundai/app/config/WebConfig.java
+++ b/src/main/java/com/hyundai/app/config/WebConfig.java
@@ -26,7 +26,8 @@ public class WebConfig extends AbstractAnnotationConfigDispatcherServletInitiali
                 ServletContextConfig.class,
                 CorsConfig.class,
                 SecurityConfig.class,
-                SwaggerConfig.class
+                SwaggerConfig.class,
+                WebSocketConfig.class
         };
     }
 

--- a/src/main/java/com/hyundai/app/config/WebSocketConfig.java
+++ b/src/main/java/com/hyundai/app/config/WebSocketConfig.java
@@ -1,0 +1,30 @@
+package com.hyundai.app.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/27
+ * 웹소켓 설정
+ */
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry config) {
+        config.enableSimpleBroker("/topic");
+        config.setApplicationDestinationPrefixes("/app");
+    }
+
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        registry.addEndpoint("/websocket-demo")
+                .setAllowedOrigins("*")
+                .withSockJS();
+    }
+}

--- a/src/main/java/com/hyundai/app/config/WebSocketConfig.java
+++ b/src/main/java/com/hyundai/app/config/WebSocketConfig.java
@@ -23,7 +23,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        registry.addEndpoint("/websocket-demo")
+        registry.addEndpoint("/websocket")
                 .setAllowedOrigins("*")
                 .withSockJS();
     }

--- a/src/main/java/com/hyundai/app/event/controller/AdminEventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/AdminEventController.java
@@ -3,6 +3,7 @@ package com.hyundai.app.event.controller;
 import com.hyundai.app.common.AdventureOfHeendyResponse;
 import com.hyundai.app.event.dto.EventDetailResDto;
 import com.hyundai.app.event.dto.EventListResDto;
+import com.hyundai.app.event.dto.EventParticipateResDto;
 import com.hyundai.app.event.dto.EventSaveReqDto;
 import com.hyundai.app.event.service.EventService;
 import io.swagger.annotations.Api;
@@ -61,5 +62,17 @@ public class AdminEventController {
         // TODO: 지점 ID 받아오는 부분 수정
         int storeId = 1;
         return AdventureOfHeendyResponse.success("이벤트를 삭제했습니다.", eventService.delete(storeId, eventId));
+    }
+
+    /**
+     * @author 엄상은
+     * @since 2024/02/27
+     * 어드민용 이벤트 참여 컨트롤러
+     */
+    @PostMapping("{eventId}/participate")
+    @ApiOperation("어드민용 이벤트 참여 API")
+    public AdventureOfHeendyResponse<EventParticipateResDto> participateEvent(@PathVariable int eventId,
+                                                                              @RequestParam String memberId){
+        return AdventureOfHeendyResponse.success("이벤트 참여에 성공했습니다.", eventService.participateEvent(memberId, eventId));
     }
 }

--- a/src/main/java/com/hyundai/app/event/controller/AdminEventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/AdminEventController.java
@@ -77,12 +77,13 @@ public class AdminEventController {
     public AdventureOfHeendyResponse<EventParticipateResDto> participateEvent(@PathVariable int eventId,
                                                                               @RequestParam String memberId){
         return AdventureOfHeendyResponse.success("이벤트 참여에 성공했습니다.", eventService.participateEvent(memberId, eventId));
+    }
 
+    /**
      * @author 최성혁
      * @since 2024/02/27
      * 이벤트 참여자 회원 목록 조회
      */
-
     @GetMapping("/{eventId}/participants")
     @ApiOperation("어드민용 이벤트 참여자 상세정보 조회 API")
     public AdventureOfHeendyResponse<List<MemberEventDetailsResDto>> findEventParticipants(@PathVariable final int eventId) {

--- a/src/main/java/com/hyundai/app/event/controller/GreetingController.java
+++ b/src/main/java/com/hyundai/app/event/controller/GreetingController.java
@@ -1,0 +1,23 @@
+package com.hyundai.app.event.controller;
+
+import lombok.extern.log4j.Log4j;
+import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.handler.annotation.SendTo;
+import org.springframework.stereotype.Controller;
+
+/**
+ * @author 엄상은
+ * @since 2024/02/27
+ * 소켓 테스트용 컨트롤러
+ */
+@Log4j
+@Controller
+public class GreetingController {
+    @MessageMapping("/hello")
+    @SendTo("/topic/greetings")
+    public String greeting(String message) throws Exception {
+        Thread.sleep(1000);
+        log.debug("서버에서 요청 받음");
+        return "Hello from server!" + message;
+    }
+}

--- a/src/main/java/com/hyundai/app/event/controller/SocketController.java
+++ b/src/main/java/com/hyundai/app/event/controller/SocketController.java
@@ -12,12 +12,11 @@ import org.springframework.stereotype.Controller;
  */
 @Log4j
 @Controller
-public class GreetingController {
+public class SocketController {
     @MessageMapping("/hello")
     @SendTo("/topic/greetings")
-    public String greeting(String message) throws Exception {
-        Thread.sleep(1000);
-        log.debug("서버에서 요청 받음");
-        return "Hello from server!" + message;
+    public String getMessageAndSend(String message) {
+        log.debug("소켓으로부터 메세지 받음: " + message);
+        return "서버에서 소켓으로 메세지 날림" + message;
     }
 }


### PR DESCRIPTION
## 구현 사항
- 어드민용 사용자 이벤트 참여 API (POST /api/v1/event/{eventId}/participate?memberId={memberId})
- 소켓 연결 설정

## 구현 상세
- 클라이언트에서 /websocket로 연결 요청 (서버와 소켓 연결)
- 클라이언트가 /topic/greetings를 구독 (유저용 클라이언트 메세지 수신)
- 클라이언트가 /app/hello에 메세지 보냄 (어드민용 클라이언트 메세지 발신)

## 참고 사항
- 백엔드, 프론트엔드, 어드민 프론트엔드 한번에 pull 받으셔야 돌아갑니다
- [Spring React 웹소켓 구현하기](https://velog.io/@toltori9/Spring-React-웹소켓-구현하기) (제 벨로그입니다..^^)

## 스크린샷
### 유저 프론트 스크린샷
<img width="512" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/63828057/9cd9b978-7897-4039-a365-9f1090d0cd00">

### 어드민 프론트 스크린샷
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/caf6cdc2-8f7e-4ee8-a62b-45666a768947)

### 백엔드 로그 스크린샷
![image](https://github.com/hyundai-fruitfruit/backend/assets/63828057/a15defda-3e1d-47cb-9e84-e870e5128b12)

## 구현 참고자료
- [Spring을 사용한 WebSocket 소개](https://recordsoflife.tistory.com/672)
- [Spring Websocket 이론과 간단한 구현](https://junuuu.tistory.com/m/738)