### PR TITLE
[HEENDY-87-fix-icon-API] 유저용 쿠폰, 이벤트 조회 시 아이콘 포함

### DIFF
--- a/src/main/java/com/hyundai/app/coupon/domain/Coupon.java
+++ b/src/main/java/com/hyundai/app/coupon/domain/Coupon.java
@@ -23,6 +23,7 @@ public class Coupon {
     private CouponType couponType;
     private String content;
     private String code;
+    private String iconUrl;
     @JsonFormat(pattern = "yyyy-MM-dd")
     private LocalDate startedAt;
     @JsonFormat(pattern = "yyyy-MM-dd")

--- a/src/main/java/com/hyundai/app/event/controller/EventController.java
+++ b/src/main/java/com/hyundai/app/event/controller/EventController.java
@@ -14,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
 
+import java.util.List;
 import java.util.Random;
 
 /**
@@ -30,8 +31,8 @@ public class EventController {
     private static final Random random = new Random();
 
     @GetMapping
-    @ApiOperation("유저용 현재 열린 이벤트 조회 API")
-    public AdventureOfHeendyResponse<EventDetailResDto> findCurrentEventByEventType(@RequestParam EventType eventType) {
+    @ApiOperation("유저용 현재 열린 이벤트 전체 조회 API")
+    public AdventureOfHeendyResponse<List<EventDetailResDto>> findCurrentEventByEventType(@RequestParam EventType eventType) {
         return AdventureOfHeendyResponse.success("이벤트 목록을 가져왔습니다.", eventService.findCurrentEventByEventType(eventType));
     }
 

--- a/src/main/java/com/hyundai/app/event/domain/Event.java
+++ b/src/main/java/com/hyundai/app/event/domain/Event.java
@@ -24,4 +24,5 @@ public class Event extends BaseEntity {
     private String reward;
     private int isDeleted;
     private int storeId;
+    private String iconUrl;
 }

--- a/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
+++ b/src/main/java/com/hyundai/app/event/dto/EventDetailResDto.java
@@ -33,6 +33,7 @@ public class EventDetailResDto {
     private int maxCount;
     private int visitedCount;
     private int couponId;
+    private String iconUrl;
     private List<EventActiveTimeZoneDto> eventActiveTimeZoneDto;
 
     public void setActiveTimeList(List<EventActiveTimeZoneDto> eventActiveTimeZoneDto) {

--- a/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
+++ b/src/main/java/com/hyundai/app/event/mapper/EventMapper.java
@@ -15,7 +15,7 @@ import java.util.List;
  */
 @Mapper
 public interface EventMapper {
-    EventDetailResDto findCurrentEventByEventType(EventType eventType);
+    List<EventDetailResDto> findCurrentEventByEventType(EventType eventType);
 
     List<EventDetailResDto> findEventList(IdWithCriteria idWithCriteria);
 

--- a/src/main/java/com/hyundai/app/event/service/EventService.java
+++ b/src/main/java/com/hyundai/app/event/service/EventService.java
@@ -35,16 +35,15 @@ public class EventService {
     private final MemberCouponMapper memberCouponMapper;
     private final CouponMapper couponMapper;
 
-    public EventDetailResDto findCurrentEventByEventType(EventType eventType) {
-        EventDetailResDto eventDetailResDto = eventMapper.findCurrentEventByEventType(eventType);
-        if (eventDetailResDto == null) {
-            log.error("해당 타입의 이벤트가 존재하지 않습니다.");
-            throw new AdventureOfHeendyException(ErrorCode.EVENT_NOT_EXIST);
+    public List<EventDetailResDto> findCurrentEventByEventType(EventType eventType) {
+        List<EventDetailResDto> eventDetailResDtoList = eventMapper.findCurrentEventByEventType(eventType);
+        for (EventDetailResDto eventDetailResDto : eventDetailResDtoList) {
+            int eventId = eventDetailResDto.getId();
+            List<EventActiveTimeZoneDto> eventActiveTimeZoneDtoList = findEventActiveTime(eventId);
+            eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDtoList);
         }
-        int eventId = eventDetailResDto.getId();
-        List<EventActiveTimeZoneDto> eventActiveTimeZoneDto = findEventActiveTime(eventId);
-        eventDetailResDto.setActiveTimeList(eventActiveTimeZoneDto);
-        return eventDetailResDto;
+
+        return eventDetailResDtoList;
     }
 
     public EventListResDto findEventList(int storeId, int page, int size) {

--- a/src/main/resources/mapper/CouponMapper.xml
+++ b/src/main/resources/mapper/CouponMapper.xml
@@ -38,6 +38,7 @@
                 , minimum_amount
                 , started_at
                 , finished_at
+                , icon_url
         FROM    coupon
         WHERE   id IN (SELECT    coupon_id
                       FROM      member_coupon

--- a/src/main/resources/mapper/EventMapper.xml
+++ b/src/main/resources/mapper/EventMapper.xml
@@ -14,6 +14,7 @@
                 , store_id
                 , reward_type
                 , reward
+                , icon_url
         FROM    event
         WHERE   sysdate BETWEEN started_at AND finished_at
         AND     id  IN  (SELECT event_id
@@ -22,7 +23,6 @@
         AND     (#{eventType} IS NULL OR event_type = #{eventType})
         AND     max_count >= visited_count
         AND     is_deleted = 0
-        FETCH   FIRST 1 ROWS ONLY
     </select>
 
     <select id="findEventList" parameterType="idwithcriteria" resultType="eventdetailresdto">


### PR DESCRIPTION
## 구현 사항
- 유저용 쿠폰, 이벤트 조회 시 아이콘 포함
- 유저용 현재 이벤트 전체 조회 (GET /api/v1/events)
- 유저용 모든 쿠폰 전체 조회 (GET /api/v1/coupons)

## 참고 사항
- S3 icon/ 폴더에 저장된 이미지 url로 이용 (현재는 아이콘 하나만 업로드 되어있음)
- DB 쿠폰, 이벤트 테이블에 icon_url 컬럼 추가

## POSTMAN 스크린샷
### 유저용 현재 이벤트 전체 조회 (GET /api/v1/events)
<img width="1039" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/63828057/118c1cf3-badc-4260-86c2-64ea2534232d">

### 유저용 모든 쿠폰 전체 조회 (GET /api/v1/coupons)
<img width="1044" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/63828057/185a523f-1275-4c1d-b01b-b222c261c7f6">