### PR TITLE
fix: Security AuthTokenFilter에서 에러 잡고 다음 필터로 넘기도록 설정 변경

### DIFF
--- a/src/main/java/com/hyundai/app/config/SecurityConfig.java
+++ b/src/main/java/com/hyundai/app/config/SecurityConfig.java
@@ -36,9 +36,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) {
         web.ignoring().antMatchers(
-                "/", "/resources/**",
-                "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html", "/swagger-ui.html","/webjars/**", "/swagger/**",   // swagger
-                "/api/v1/auth/**", "/api/v1/admin/**", "/api/v1/fcm-push/**", "/api/v1/heendy-guide/**", "/websocket/**");
+                "/", "/resources/**"
+                , "/v2/api-docs", "/swagger-resources/**", "/swagger-ui/index.html"
+                , "/swagger-ui.html","/webjars/**", "/swagger/**"   // swagger
+                );
     }
 
     @Override
@@ -60,9 +61,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
                     .accessDeniedHandler(authTokenAccessDeniedHandler)
                 .and()
                     .authorizeRequests()
-                    .antMatchers("/api/v1/auth/**").permitAll()
-                    .antMatchers("/api/v1/admin/**").permitAll()
-                    .antMatchers("/api/v1/fcm/**").permitAll()
+                .antMatchers("/api/v1/auth/**"
+                            ,"/api/v1/admin/**"
+                            , "/api/v1/fcm-push/**"
+                            , "/api/v1/auth/**"
+                            , "/api/v1/admin/**"
+                            , "/api/v1/fcm-push/random-spot/**"
+                            , "/api/v1/heendy-guide/**"
+                            , "/websocket/**").permitAll()
                     .antMatchers("/api/v1/stores/**").authenticated()
                     .antMatchers("/api/v1/members/**").authenticated()
                     .anyRequest().permitAll()

--- a/src/main/java/com/hyundai/app/member/controller/MemberController.java
+++ b/src/main/java/com/hyundai/app/member/controller/MemberController.java
@@ -22,7 +22,6 @@ import springfox.documentation.annotations.ApiIgnore;
  */
 @Log4j
 @Api("회원 관련 API")
-@RequiredArgsConstructor
 @RestController
 @RequestMapping("/api/v1/members")
 public class MemberController {

--- a/src/main/java/com/hyundai/app/security/filter/AuthTokenFilter.java
+++ b/src/main/java/com/hyundai/app/security/filter/AuthTokenFilter.java
@@ -41,13 +41,15 @@ public class AuthTokenFilter extends OncePerRequestFilter {
             log.debug("AuthTokenFilter : request " + request);
             String accessToken = resolveToken(request);
             log.debug("AuthTokenFilter : accessToken " + accessToken);
-            jwtTokenGenerator.isTokenValidate(accessToken);
+            if (!jwtTokenGenerator.isTokenValidate(accessToken)) {
+                log.error("AuthTokenFilter ERROR : accessToken 토큰이 유효하지 않습니다.");
+                throw new AdventureOfHeendyException(ErrorCode.ACCESS_TOKEN_INVALID);
+            }
 
             Authentication authentication = createAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
         } catch (Exception e) {
-            log.debug("AuthTokenFilter : accessToken 토큰이 유효하지 않습니다.");
-            throw new AdventureOfHeendyException(ErrorCode.ACCESS_TOKEN_INVALID);
+            log.error("AuthTokenFilter ERROR catch! accessToken 토큰이 유효하지 않습니다.");
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/hyundai/app/security/jwt/JwtTokenGenerator.java
+++ b/src/main/java/com/hyundai/app/security/jwt/JwtTokenGenerator.java
@@ -96,13 +96,15 @@ public class JwtTokenGenerator implements InitializingBean {
      * @since 2024/02/14
      * 토큰 유효성 검증
      */
-    public void isTokenValidate(String token) {
+    public boolean isTokenValidate(String token) {
         try {
             Jwts.parser()
                 .setSigningKey(jwtSecret)
                 .parseClaimsJws(token);
+            return true;
         } catch (JwtException | IllegalArgumentException e) {
-            throw new AdventureOfHeendyException(ErrorCode.ACCESS_TOKEN_INVALID);
+            log.error("isTokenValidate() 토큰 파싱 시, 에러 발생 ");
         }
+        return false;
     }
 }


### PR DESCRIPTION
## 구현 사항
- AuthTokenFilter에서 바로 에러 throw하지 않도록 변경 ->인증이 유효하지 않아도 이후 필터로 진행
- **permitAll() 사용하기 위해 변경! 이제 인증 필요없는 것들은 permitAll()로 선언해주면 됩니다!**
- permitAll()은 필터를 안거치는 게(인증을 안하는 게 아니라), 인증이 유효하지 않아도 이후 필터로 계속 진행해서 api 호출한다는 의미입니다
- 반면 아예 필터단을 안 거치려면 web.ignoring()에 경로 등록해주면 됩니다!



## 참고 사항

