### PR TITLE
[HEENDY-47-review-image] 리뷰 작성 시, 다중 이미지 업로드(S3) 구현

### DIFF
--- a/src/main/java/com/hyundai/app/config/ServletContextConfig.java
+++ b/src/main/java/com/hyundai/app/config/ServletContextConfig.java
@@ -2,10 +2,12 @@ package com.hyundai.app.config;
 
 import com.hyundai.app.security.methodparam.AuthParameterResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.MediaType;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.multipart.commons.CommonsMultipartResolver;
 import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
@@ -42,4 +44,15 @@ public class ServletContextConfig implements WebMvcConfigurer {
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(authParameterResolver);
     }
+
+    @Bean
+    public CommonsMultipartResolver multipartResolver() {
+        CommonsMultipartResolver resolver = new CommonsMultipartResolver();
+        resolver.setDefaultEncoding("UTF-8");
+        resolver.setMaxUploadSize(104857560); // 10MB
+        resolver.setMaxUploadSizePerFile(2097152); // 2MB
+        resolver.setMaxInMemorySize(10485756);
+        return resolver;
+    }
+
 }

--- a/src/main/java/com/hyundai/app/member/service/AwsS3Config.java
+++ b/src/main/java/com/hyundai/app/member/service/AwsS3Config.java
@@ -5,18 +5,29 @@ import com.amazonaws.auth.BasicAWSCredentials;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.hyundai.app.exception.AdventureOfHeendyException;
+import com.hyundai.app.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
 
 /**
  * @author 엄상은
  * @since 2024/02/26
  * AWS S3 서비스
  */
+@Log4j
 @Component
+@RequiredArgsConstructor
 public class AwsS3Config {
     @Value("${aws.s3.access-key}")
     private String accessKey;
@@ -43,4 +54,5 @@ public class AwsS3Config {
         );
         return s3Client.getUrl(bucket, fileName).toString();
     }
+
 }

--- a/src/main/java/com/hyundai/app/store/controller/StoreController.java
+++ b/src/main/java/com/hyundai/app/store/controller/StoreController.java
@@ -12,6 +12,10 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import springfox.documentation.annotations.ApiIgnore;
+import org.springframework.http.MediaType;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 /**
  * @author 황수영
@@ -45,15 +49,15 @@ public class StoreController {
      * @since 2024/02/14
      * 매장 리뷰 작성
      */
-    @PostMapping("/{storeId}/reviews")
+    @PostMapping(value = "/{storeId}/reviews", consumes = {MediaType.MULTIPART_FORM_DATA_VALUE})
     @ApiOperation("매장 리뷰 작성 API")
     public ResponseEntity<Void> createReview(
             @PathVariable int storeId,
-            @RequestBody ReviewReqDto reviewReqDto,
+            @RequestPart(value = "reviewReqDto") ReviewReqDto reviewReqDto,
+            @RequestPart(value = "imageList", required = false) List<MultipartFile> imageList,
             @ApiIgnore @MemberId String memberId
     ) {
-        storeService.createReview(storeId, memberId, reviewReqDto);
+        storeService.createReview(storeId, memberId, reviewReqDto, imageList);
         return new ResponseEntity<>(HttpStatus.ACCEPTED);
     }
-
 }

--- a/src/main/java/com/hyundai/app/store/domain/Review.java
+++ b/src/main/java/com/hyundai/app/store/domain/Review.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {
 
-    private int id;
+    private String id;
     private String memberId;
     private int storeId;
     private int isDeleted;
@@ -26,8 +26,9 @@ public class Review extends BaseEntity {
     private String content;
     private List<Integer> hashtags;
 
-    public static Review create(ReviewReqDto reviewReqDto, int storeId, String memberId) {
+    public static Review of(String id, ReviewReqDto reviewReqDto, int storeId, String memberId) {
         return Review.builder()
+                .id(id)
                 .score(reviewReqDto.getScore())
                 .content(reviewReqDto.getContent())
                 .memberId(memberId)

--- a/src/main/java/com/hyundai/app/store/dto/ReviewReqDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/ReviewReqDto.java
@@ -14,5 +14,4 @@ public class ReviewReqDto {
     private int score;
     private String content;
     private List<Integer> hashtagIds;
-    // 이미지 이후에 추가
 }

--- a/src/main/java/com/hyundai/app/store/dto/ReviewResDto.java
+++ b/src/main/java/com/hyundai/app/store/dto/ReviewResDto.java
@@ -18,7 +18,7 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ReviewResDto {
-    private int id;
+    private String id;
     private int score;
     private String content;
     private List<String> hashtags;

--- a/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
+++ b/src/main/java/com/hyundai/app/store/mapper/StoreMapper.java
@@ -20,4 +20,6 @@ public interface StoreMapper {
     void updateReviewCount(@Param("storeId") int storeId);
     List<Review> getReviews(@Param("storeId") int storeId);
     List<Store> getStoresByHashtagId(@Param("hashtagId") int hashtagId);
+    void saveReviewImage(@Param("reviewId") String reviewId, @Param("memberId") String memberId
+            , @Param("storeId") int storeId, @Param("image") String image);
 }

--- a/src/main/java/com/hyundai/app/store/service/S3ImageUploadService.java
+++ b/src/main/java/com/hyundai/app/store/service/S3ImageUploadService.java
@@ -1,0 +1,95 @@
+package com.hyundai.app.store.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PutObjectRequest;
+import com.hyundai.app.exception.AdventureOfHeendyException;
+import com.hyundai.app.exception.ErrorCode;
+import com.hyundai.app.member.service.AwsS3Config;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.UUID;
+
+/**
+ * @author 황수영
+ * @since 2024/03/04
+ * 리뷰 작성시, S3 이미지 다중 업로드 기능 구현용
+ */
+@Log4j
+@Component
+@RequiredArgsConstructor
+public class S3ImageUploadService {
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    private final AwsS3Config awsS3Config; // TODO: AmazonS3 싱글톤으로 정의하기
+    
+    /**
+     * @author 황수영
+     * @since 2024/03/03
+     * 리뷰 작성 시 이미지 다중 업로드
+     */
+    public List<String> uploadReviewImages(List<MultipartFile> multipartFilelist) {
+        List<String> urlList = new ArrayList<>();
+        for (MultipartFile multipartFile : multipartFilelist){
+            String url = uploadImage(multipartFile);
+            urlList.add(url);
+        }
+        return urlList;
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/03/03
+     * 파일 개별 업로드 후, url 반환
+     */
+    public String uploadImage(MultipartFile file)  {
+        try (InputStream inputStream = file.getInputStream()) {
+            String fileName = UUID.randomUUID().toString()
+                    .concat(getFileExtension(Objects.requireNonNull(file.getOriginalFilename())));
+
+            ObjectMetadata objectMetadata = new ObjectMetadata();
+            objectMetadata.setContentLength(file.getSize());
+            objectMetadata.setContentType(file.getContentType());
+            uploadFile(inputStream, objectMetadata, fileName);
+            return getFileUrl(fileName);
+        } catch(IllegalAccessException | IOException e) {
+            log.error("파일 변환 중 에러가 발생하였습니다. => 파일명 : " + file.getOriginalFilename());
+            throw new AdventureOfHeendyException(ErrorCode.SERVER_UNAVAILABLE);
+        }
+    }
+
+    /**
+     * @author 황수영
+     * @since 2024/03/03
+     * 파일의 확장자명 가져오기
+     */
+    private String getFileExtension(String fileName) throws IllegalAccessException {
+        try {
+            return fileName.substring(fileName.lastIndexOf("."));
+        } catch (StringIndexOutOfBoundsException e) {
+            log.error("파일 형식이 유효하지 않습니다. => 파일명 : " + fileName);
+            throw new AdventureOfHeendyException(ErrorCode.SERVER_UNAVAILABLE);
+        }
+    }
+
+    public void uploadFile(InputStream inputStream, ObjectMetadata objectMeTadata, String fileName){
+        awsS3Config.AmazonS3Client().putObject(new PutObjectRequest(bucket, fileName, inputStream, objectMeTadata)
+                .withCannedAcl(CannedAccessControlList.PublicRead));
+    }
+
+    public  String getFileUrl(String fileName){
+        return awsS3Config.AmazonS3Client().getUrl(bucket, fileName).toString();
+    }
+}

--- a/src/main/java/com/hyundai/app/store/service/StoreService.java
+++ b/src/main/java/com/hyundai/app/store/service/StoreService.java
@@ -2,6 +2,7 @@ package com.hyundai.app.store.service;
 
 import com.hyundai.app.store.dto.ReviewReqDto;
 import com.hyundai.app.store.dto.StoreResDto;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -13,6 +14,6 @@ import java.util.List;
 public interface StoreService {
 
     StoreResDto getStoreDetail(int storeId);
-    void createReview(int storeId, String memberId, ReviewReqDto reviewReqDto);
+    void createReview(int storeId, String memberId, ReviewReqDto reviewReqDto, List<MultipartFile> imagelist);
     void createStoreHashtag(int storeId, List<Integer> hashtagIds);
 }

--- a/src/main/resources/mapper/StoreMapper.xml
+++ b/src/main/resources/mapper/StoreMapper.xml
@@ -55,7 +55,7 @@
             , content
         )
         VALUES (
-            review_id_seq.nextval
+            #{review.id}
             , #{review.memberId}
             , #{review.storeId}
             , #{review.score}
@@ -92,4 +92,21 @@
         ORDER BY store_hashtag.count DESC
         FETCH FIRST 5 ROWS ONLY
     </select>
+
+    <insert id="saveReviewImage" >
+        INSERT INTO image (
+            id
+            , img_url
+            , store_id
+            , member_id
+            , review_id
+            )
+        VALUES (
+            image_id_seq.nextval
+            , #{image}
+            , #{storeId}
+            , #{memberId}
+            , #{reviewId}
+        )
+    </insert>
 </mapper>


### PR DESCRIPTION
## 구현 사항
- 리뷰 작성 시, 다중 이미지 업로드 기능 구현 (리뷰 내용은 필수, 이미지는 선택!)
- POSTMAN 데탑 버전만 파일 업로드되고 브라우저는 로컬 파일이 안됨 참고해주세욥


<img width="650" alt="image" src="https://github.com/hyundai-fruitfruit/backend/assets/77563814/b9a07ffe-e54a-49be-b5e6-6e5829a93171">

- ‼️ **리뷰에 이미지 추가 시, 리뷰 저장 전 이므로 아직 reviewId(PK)를 몰라서 이미지 테이블에 reviewId 추가 못함**
   => 리뷰 저장하고, 이미지는 그 이후에 저장할까 했지만, 한번에 트랜잭션 처리하는 게 우선인 것 같아서
   => 일단 FK 설정 제외


![image](https://github.com/hyundai-fruitfruit/backend/assets/77563814/34465426-81bb-4d88-b0ec-266f1ca8f821)




## 참고 사항

- https://techblog.woowahan.com/11392/
